### PR TITLE
BUG: Shadowing warning for IndexValueType in GLSliceView,h

### DIFF
--- a/FltkImageViewer/GLSliceView.h
+++ b/FltkImageViewer/GLSliceView.h
@@ -1076,10 +1076,10 @@ void GLSliceView<ImagePixelType, OverlayPixelType>::draw(void)
       if( this->cViewValuePhysicalUnits )
         {
         IndexType index;
-        typedef typename IndexType::IndexValueType    IndexValueType;
-        index[0] = static_cast< IndexValueType >( this->cClickSelect[0] );
-        index[1] = static_cast< IndexValueType >( this->cClickSelect[1] );
-        index[2] = static_cast< IndexValueType >( this->cClickSelect[2] );
+        typedef typename IndexType::IndexValueType indexValueType;
+        index[0] = static_cast< indexValueType >( this->cClickSelect[0] );
+        index[1] = static_cast< indexValueType >( this->cClickSelect[1] );
+        index[2] = static_cast< indexValueType >( this->cClickSelect[2] );
         PointType point;
         this->cImData->TransformIndexToPhysicalPoint( index, point );
         px = point[0];


### PR DESCRIPTION
Should fix a shadowing warning when superbuilding TubeTK
