### PR TITLE
ENH: Explicit specification of ITK COMPONENTS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,21 +75,8 @@ if(ImageViewer_USE_SUPERBUILD)
   return()
 else(ImageViewer_USE_SUPERBUILD)
 
-  find_package(ITK REQUIRED)
-  set( ITK_NO_IO_FACTORY_REGISTER_MANAGER 1 )
-  include(${ITK_USE_FILE})
-
   find_package(Qt4 COMPONENTS QtCore QtGui QtNetwork QtOpenGL QtWebkit REQUIRED)
   include(${QT_USE_FILE})
-
-  if(USE_CLI)
-
-    find_package(SlicerExecutionModel REQUIRED)
-    include(${SlicerExecutionModel_USE_FILE})
-
-    find_package(SlicerExecutionModel REQUIRED GenerateCLP)
-    include(${GenerateCLP_USE_FILE})
-  endif(USE_CLI)
 
   add_subdirectory(QtImageViewer)
   add_subdirectory(ImageViewer)

--- a/ImageViewer/CMakeLists.txt
+++ b/ImageViewer/CMakeLists.txt
@@ -42,6 +42,9 @@ list(APPEND ${MODULE_NAME}_INCLUDE_DIRS
     ${${MODULE_NAME}_BINARY_DIR}/QtImageViewer)
 include_directories(${${MODULE_NAME}_INCLUDE_DIRS})
 
+find_package(ITK REQUIRED COMPONENTS ITKCommon)
+include(${ITK_USE_FILE})
+
 set(${MODULE_NAME}_SRCS ImageViewer.cxx)
 set(${MODULE_NAME}_LIBRARIES
     QtImageViewer
@@ -56,6 +59,11 @@ if(BUILD_SHARED_LIBS)
 endif(BUILD_SHARED_LIBS)
 
 if(USE_CLI)
+  find_package(SlicerExecutionModel REQUIRED)
+  include(${SlicerExecutionModel_USE_FILE})
+
+  find_package(SlicerExecutionModel REQUIRED GenerateCLP)
+  include(${GenerateCLP_USE_FILE})
 
   SEMMacroBuildCLI(
     ${BUILD_EXEC_ONLY}

--- a/QtImageViewer/CMakeLists.txt
+++ b/QtImageViewer/CMakeLists.txt
@@ -34,10 +34,6 @@
 #
 ##############################################################################
 
-if(USE_ITK_FILE)
-   include(${USE_ITK_FILE})
-endif(USE_ITK_FILE)
-
 include(GenerateExportHeader)
 
 include_directories(
@@ -48,6 +44,27 @@ include_directories(
 
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIRS})
+find_package(ITK REQUIRED COMPONENTS
+  ITKCommon
+  ITKIOImageBase
+  ITKIONIFTI
+  ITKIONRRD
+  ITKIOGIPL
+  ITKIOHDF5
+  ITKIOJPEG
+  ITKIOGDCM
+  ITKIOBMP
+  ITKIOLSM
+  ITKIOPNG
+  ITKIOTIFF
+  ITKIOVTK
+  ITKIOStimulate
+  ITKIOBioRad
+  ITKIOMeta
+  ITKIOMRC
+  ITKIOGE
+  )
+include(${ITK_USE_FILE})
 
 set(QtImageViewer_SRCS
   QtGlSliceView.cxx


### PR DESCRIPTION
SlicerExecutionModel uses find_package(ITK COMPONENTS ...)

Mixing and matching find_package calls with and without COMPONENTS is not very
well supported at the moment.

Use explicit specification of the ITK components and make find_package calls
appropriately local in scope..
