### PR TITLE
ENH: Do not build SlicerExecutionModel if its path is provided

### DIFF
--- a/CMake/Superbuild/External_SlicerExecutionModel.cmake
+++ b/CMake/Superbuild/External_SlicerExecutionModel.cmake
@@ -29,8 +29,6 @@ if( ${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED )
 endif( ${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED )
 set( ${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED 1 )
 
-set( proj SlicerExecutionModel )
-
 # Sanity checks.
 if( DEFINED SlicerExecutionModel_DIR AND NOT EXISTS ${SlicerExecutionModel_DIR} )
   message( FATAL_ERROR "SlicerExecutionModel_DIR variable is defined but corresponds to a nonexistent directory" )
@@ -42,36 +40,45 @@ set( SlicerExecutionModel_DEPENDENCIES "ITK" )
 # Include dependent projects, if any.
 CheckExternalProjectDependency( SlicerExecutionModel )
 
-set( SlicerExecutionModel_SOURCE_DIR ${CMAKE_BINARY_DIR}/SlicerExecutionModel )
-set( SlicerExecutionModel_DIR ${CMAKE_BINARY_DIR}/SlicerExecutionModel-build )
+if( NOT DEFINED SlicerExecutionModel_DIR AND NOT USE_SYSTEM_SlicerExecutionModel )
+  set( SlicerExecutionModel_SOURCE_DIR ${CMAKE_BINARY_DIR}/SlicerExecutionModel )
+  set( SlicerExecutionModel_DIR ${CMAKE_BINARY_DIR}/SlicerExecutionModel-build )
 
-ExternalProject_Add( SlicerExecutionModel
-  GIT_REPOSITORY ${SlicerExecutionModel_URL}
-  GIT_TAG ${SlicerExecutionModel_HASH_OR_TAG}
-  DOWNLOAD_DIR ${SlicerExecutionModel_SOURCE_DIR}
-  SOURCE_DIR ${SlicerExecutionModel_SOURCE_DIR}
-  BINARY_DIR ${SlicerExecutionModel_DIR}
-  INSTALL_DIR ${SlicerExecutionModel_DIR}
-  CMAKE_GENERATOR ${gen}
-  LOG_DOWNLOAD 1
-  LOG_UPDATE 0
-  LOG_CONFIGURE 0
-  LOG_BUILD 0
-  LOG_TEST 0
-  LOG_INSTALL 0
-  UPDATE_COMMAND ""
-  CMAKE_ARGS
-    -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-    -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
-    -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-    -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-    -DCMAKE_EXE_LINKER_FLAGS:STRING=${CMAKE_EXE_LINKER_FLAGS}
-    -DCMAKE_SHARED_LINKER_FLAGS:STRING=${CMAKE_SHARED_LINKER_FLAGS}
-    -DCMAKE_BUILD_TYPE:STRING=${build_type}
-    ${CMAKE_OSX_EXTERNAL_PROJECT_ARGS}
-    -DBUILD_SHARED_LIBS:BOOL=${shared}
-    -DBUILD_TESTING:BOOL=OFF
-    -DITK_DIR:PATH=${ITK_DIR}
-  INSTALL_COMMAND ""
-  DEPENDS
-    ${SlicerExecutionModel_DEPENDENCIES} )
+  ExternalProject_Add( SlicerExecutionModel
+    GIT_REPOSITORY ${SlicerExecutionModel_URL}
+    GIT_TAG ${SlicerExecutionModel_HASH_OR_TAG}
+    DOWNLOAD_DIR ${SlicerExecutionModel_SOURCE_DIR}
+    SOURCE_DIR ${SlicerExecutionModel_SOURCE_DIR}
+    BINARY_DIR ${SlicerExecutionModel_DIR}
+    INSTALL_DIR ${SlicerExecutionModel_DIR}
+    CMAKE_GENERATOR ${gen}
+    LOG_DOWNLOAD 1
+    LOG_UPDATE 0
+    LOG_CONFIGURE 0
+    LOG_BUILD 0
+    LOG_TEST 0
+    LOG_INSTALL 0
+    UPDATE_COMMAND ""
+    CMAKE_ARGS
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+      -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+      -DCMAKE_EXE_LINKER_FLAGS:STRING=${CMAKE_EXE_LINKER_FLAGS}
+      -DCMAKE_SHARED_LINKER_FLAGS:STRING=${CMAKE_SHARED_LINKER_FLAGS}
+      -DCMAKE_BUILD_TYPE:STRING=${build_type}
+      ${CMAKE_OSX_EXTERNAL_PROJECT_ARGS}
+      -DBUILD_SHARED_LIBS:BOOL=${shared}
+      -DBUILD_TESTING:BOOL=OFF
+      -DITK_DIR:PATH=${ITK_DIR}
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${SlicerExecutionModel_DEPENDENCIES} )
+else( NOT DEFINED SlicerExecutionModel_DIR AND NOT USE_SYSTEM_SlicerExecutionModel )
+  if( USE_SYSTEM_SlicerExecutionModel )
+    find_package( SlicerExecutionModel REQUIRED )
+  endif( USE_SYSTEM_SlicerExecutionModel )
+
+  AddEmptyExternalProject( SlicerExecutionModel "${SlicerExecutionModel_DEPENDENCIES}" )
+endif( NOT DEFINED SlicerExecutionModel_DIR AND NOT USE_SYSTEM_SlicerExecutionModel )
+


### PR DESCRIPTION
In a previous commit (5480a6b32aec3df372f08fc18882e8646ca8b8a5 [1]), External_SlicerExecutionModel.cmake has been modified and does not check if SlicerExecutionModel_DIR is defined before creating the external project to download and compile SlicerExecutionModel. Even if it is provided and if USE_SYSTEM_SLICER_EXECUTION_MODEL is set to ON, the external project for SlicerExecutionModel was still used.

[1] https://github.com/KitwareMedical/ImageViewer/commit/5480a6b32aec3df372f08fc18882e8646ca8b8a5#diff-2ead5608565906a4e7f5d574e7363861
