### PR TITLE
ENH: TravisCI is now configured with Qt4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ compiler:
 before_install:
   - sudo add-apt-repository --yes ppa:jamie-snape/tubetk
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libfltk1.3-dev libinsighttoolkit-dev
+  - sudo apt-get install -qq libinsighttoolkit-dev qt4-dev-tools
 
 script:
   - mkdir _build
   - cd _build
-  - cmake -DUSE_SYSTEM_FLTK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON ..
+  - cmake -DUSE_SYSTEM_ITK:BOOL=ON ..
   - cmake --build .


### PR DESCRIPTION
ImageViewer does not use FLTK anymore. All references to FLTK have been removed and replaced by Qt.
