### PR TITLE
ENH: Missing new line character when printing input file name.

### DIFF
--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -163,8 +163,7 @@ typename itk::Image<PixelType, 3>::Pointer QtImageViewerPrivate::readImage(
   typename ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( filePath.toLatin1().data() );
 
-  std::cout << "Read image " << filePath.toStdString() << "...";
-  std::cout.flush();
+  std::cout << "Read image " << filePath.toStdString() << "..." << std::endl ;
   typename itk::Image<PixelType, 3>::Pointer res;
   try
     {


### PR DESCRIPTION
ImageViewer prints the image file name that is loaded, but no
new line character was inserted. After exiting ImageViewer, the
new prompt line was written after the file name that had been loaded
instead of being written on a clean new line.
