### PR TITLE
ENH: Fix morphology radius to 2 voxels

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -201,7 +201,7 @@ void myMouseCallback(double x, double y, double z, double v, void *d)
         double tf = seed[d] - PRESS_SEED[d];
         cropMaxSize += tf * tf;
         }
-      int morphRadius = cropMaxSize / 5;
+      int morphRadius = 2; //cropMaxSize / 5;
       if( morphRadius > 8 )
         {
         morphRadius = 8;


### PR DESCRIPTION
Interactivity degrades with too large of a morphology radius.  Instead
of the radius being proportional to the distance the mouse was dragged,
in this version it is fixed at 2 voxels.  The assumption is that most
image noise is on the order of 1 voxels.   Meh.