### PR TITLE
ENH: Ruler Widget

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -424,6 +424,7 @@ int parseAndExecImageViewer(int argc, char* argv[])
   viewer.sliceView()->setKeyEventArg( (void*)(viewer.sliceView()) );
 
   viewer.sliceView()->setPaintRadius( 10 );
+  viewer.sliceView()->setIsONSDRuler(ONSDRuler);
   //viewer.sliceView()->setPaintColor( 0 );
   //viewer.sliceView()->setClickMode( CM_CUSTOM );
 

--- a/ImageViewer/ImageViewer.xml
+++ b/ImageViewer/ImageViewer.xml
@@ -185,6 +185,14 @@
             <label>Clipping or setting</label>
             <description>Toggle between clipping and setting to black values above IW lower limit.</description>
         </string-enumeration>
+        <boolean>
+          <name>ONSDRuler</name>
+          <flag>R</flag>
+          <longflag>ONSDRuler</longflag>
+          <default>false</default>
+          <label>ONSD Ruler</label>
+          <description>Set the default ruler (rainbow) to optic nerve sheathe diamter (ONSD)</description>
+        </boolean>
     </parameters>
 </executable>
 

--- a/QtImageViewer/CMakeLists.txt
+++ b/QtImageViewer/CMakeLists.txt
@@ -48,6 +48,7 @@ include_directories( ${OPENGL_INCLUDE_DIRS} )
 set( QtImageViewer_SRCS
   QtGlSliceView.cxx
   QtImageViewer.cxx
+  RulerWidget.cxx
   )
 
 set( QtImageViewer_GUI_SRCS

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -47,6 +47,7 @@ limitations under the License.
 #include <QScrollArea>
 #include <QBoxLayout>
 #include <QTextEdit>
+#include <memory>
 
 QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   : QOpenGLWidget( widgetParent )
@@ -171,6 +172,14 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   QSizePolicy sP = this->sizePolicy();
   sP.setHeightForWidth( true );
   this->setSizePolicy( sP );
+  
+  // this->setMouseTracking(true); // removed, set in the .ui file
+
+ 
+  cONSDMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< ONSDMetaDataGenerator >(new ONSDMetaDataGenerator())));
+  cRainbowMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< RainbowMetaDataGenerator >(new RainbowMetaDataGenerator())));
+  isONSDRuler = false;
+  cCurrentRulerMetaFactory = cRainbowMetaFactory;
   update();
 }
 
@@ -396,6 +405,36 @@ void QtGlSliceView::saveClickedPointsStored()
   fpoints.close();
 }
 
+void QtGlSliceView::saveRulers()
+{
+    QFileInfo fileInfo(this->inputImageFilepath);
+    QString newFilepath = fileInfo.path() + "/" + fileInfo.completeBaseName() + ".json";    
+    QString fileName = QFileDialog::getSaveFileName(this,
+        "Save ruler measurements", newFilepath, "*.*");
+    if (fileName.isNull())
+    {
+        return;
+    }
+    QFile fpoints(fileName);
+    if (!fpoints.open(QIODevice::ReadWrite | QIODevice::Truncate)) // write and overwrite
+    {
+        return;
+    }
+    QTextStream text(&fpoints);
+    text << "{ \"rulers\" : [";
+    bool isFirst = true;
+    for (auto& node : cRulerCollections) 
+    {
+            auto& rc = node.second;
+            std::string sep = isFirst ? "" : ",";
+            if (node.second->rulers.size() > 0) {
+                text << sep.c_str() << rc->toJson().c_str();
+                isFirst = false;
+            }
+    }
+    text << "]}";
+    fpoints.close();
+}
 
 void
 QtGlSliceView::update()
@@ -844,7 +883,7 @@ void QtGlSliceView::showHelp()
     str << QString("         - Blend with previous and next slice");
     str << QString("         - MIP");
     str << QString("    ");
-    str << QString("   \\ - cycle between mouse Modes: Select Points, Custom, Paint");
+    str << QString("   \\ - cycle between mouse Modes: Select Points, Custom, Ruler, Paint");
     str << QString("        - Default Custom is threshold connected components");
     str << QString("    ");
     str << QString("   Paint mode: ");
@@ -854,6 +893,11 @@ void QtGlSliceView::showHelp()
     str << QString("    ");
     str << QString("   Image processing ");
     str << QString("   \' - Perform median filtering with radius=1");
+    str << QString("    ");
+    str << QString("   Ruler Measurements ");
+    str << QString("   Left click to set ruler.  Right-click over X to move or delete");
+    str << QString("   u - Toggle between rainbow ruler and ONSD measurements");
+    str << QString("   ctrl-U - Save measurements to JSON");
     for( auto &data : str )
       {
       help->append( data );
@@ -1325,105 +1369,113 @@ void QtGlSliceView::setIWModeMax( IWModeType newIWModeMax )
 }
 
 
-IWModeType QtGlSliceView::iwModeMax( void ) const
+IWModeType QtGlSliceView::iwModeMax(void) const
 {
-  return cIWModeMax;
+    return cIWModeMax;
 }
 
 
-void QtGlSliceView::keyPressEvent( QKeyEvent* keyEvent )
+void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
 {
-  int movePace;
-  double iwPace;
-  int imgShiftSize = static_cast< int >( (cWinSizeX/10)/zoom() );
-  if( imgShiftSize < 1 )
+    int movePace;
+    double iwPace;
+    int imgShiftSize = static_cast<int>((cWinSizeX / 10) / zoom());
+    if (imgShiftSize < 1)
     {
-    imgShiftSize = 1;
+        imgShiftSize = 1;
     }
 
-  switch ( keyEvent->key() )
+    switch (keyEvent->key())
     {
     case Qt::Key_0:
-      setOrientation( X_AXIS );
-      transpose( true );
-      update();
-      break;
+        setOrientation(X_AXIS);
+        transpose(true);
+        update();
+        break;
     case Qt::Key_1:
-      setOrientation( Y_AXIS );
-      transpose( false );
-      update();
-      break;
+        setOrientation(Y_AXIS);
+        transpose(false);
+        update();
+        break;
     case Qt::Key_2:
-      setOrientation( Z_AXIS );
-      transpose( false );
-      update();
-      break;
+        setOrientation(Z_AXIS);
+        transpose(false);
+        update();
+        break;
     case Qt::Key_Less: // <
     case Qt::Key_Comma:
-      movePace = cFastMoveValue[ cFastPace ];
-      if( ( int )cWinCenter[cWinOrder[2]]-movePace<0 )
+        movePace = cFastMoveValue[cFastPace];
+        if ((int)cWinCenter[cWinOrder[2]] - movePace < 0)
         {
-        if( ( int )cWinCenter[cWinOrder[2]] == 0 )
-          {
-          return;
-          }
+            if ((int)cWinCenter[cWinOrder[2]] == 0)
+            {
+                return;
+            }
+            else
+            {
+                setSliceNum(0);
+            }
+        }
         else
-          {
-          setSliceNum( 0 );
-          }
-        }
-      else
         {
-        setSliceNum( ( int )cWinCenter[cWinOrder[2]]-movePace );
+            setSliceNum((int)cWinCenter[cWinOrder[2]] - movePace);
         }
-      update();
-      break;
+        update();
+        break;
     case Qt::Key_BracketRight:
-      ++cOverlayPaintRadius;
-      update();
-      break;
+        ++cOverlayPaintRadius;
+        update();
+        break;
     case Qt::Key_BracketLeft:
-      if( cOverlayPaintRadius > 1 )
+        if (cOverlayPaintRadius > 1)
         {
-        --cOverlayPaintRadius;
-        update();
+            --cOverlayPaintRadius;
+            update();
         }
-      break;
+        break;
     case Qt::Key_BraceRight:
-      if( cOverlayPaintColor < 10 )
+        if (cOverlayPaintColor < 10)
         {
-        ++cOverlayPaintColor;
-        update();
+            ++cOverlayPaintColor;
+            update();
         }
-      break;
+        break;
     case Qt::Key_BraceLeft:
-      if( cOverlayPaintColor > 0 )
+        if (cOverlayPaintColor > 0)
         {
-        --cOverlayPaintColor;
-        update();
+            --cOverlayPaintColor;
+            update();
         }
-      break;
+        break;
     case Qt::Key_QuoteDbl:
-      saveOverlay();
-      break;
+        saveOverlay();
+        break;
     case Qt::Key_Backslash:
-      if( cClickMode == CM_SELECT )
+        if (cClickMode == CM_SELECT)
         {
-        if( !cValidOverlayData )
-          {
-          createOverlay();
-          }
-        cClickMode = CM_CUSTOM;
-        update();
+            if (!cValidOverlayData)
+            {
+                createOverlay();
+            }
+            cClickMode = CM_CUSTOM;
+            update();
         }
-      else if( cClickMode == CM_CUSTOM )
+        else if (cClickMode == CM_CUSTOM)
         {
-        if( !cValidOverlayData )
-          {
-          createOverlay();
-          }
-        cClickMode = CM_PAINT;
-        update();
+            if (!cValidOverlayData)
+            {
+                createOverlay();
+            }
+            cClickMode = CM_RULER;
+            update();
+        }
+        else if ( cClickMode == CM_RULER ) {
+            if (!cValidOverlayData)
+            {
+                createOverlay();
+            }
+            cClickMode = CM_PAINT;
+            update();
         }
       else
         {
@@ -1476,6 +1528,16 @@ void QtGlSliceView::keyPressEvent( QKeyEvent* keyEvent )
       flipZ( !isZFlipped() );
       update();
       break;
+    case Qt::Key_U:
+        if (cClickMode == CM_RULER) {
+            if (keyEvent->modifiers() & Qt::CTRL) {
+                saveRulers();
+            }
+            else {
+                setIsONSDRuler(!isONSDRuler);
+            }
+        }
+        break;
     case Qt::Key_E:
       setIWModeMax( iwModeMax() == IW_FLIP ? IW_MAX : IW_FLIP );
       update();
@@ -1939,6 +2001,36 @@ void QtGlSliceView::paintGL( void )
     this->renderText( posX, posY, s, widgetFont );
     glDisable( GL_BLEND );
     }
+  else if (cClickMode == CM_RULER)
+  {
+      glEnable(GL_BLEND);
+      glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+      glColor4f(0.1, 0.64, 0.2, (double)0.75);
+      char s[80];
+      sprintf(s, "RULER: Ruler Widget");
+      int posX = width() - widgetFontMetric.width(s)
+          - widgetFontMetric.width("00");
+      int posY = height() - 2 * (widgetFontMetric.height() + 1);
+      this->renderText(posX, posY, s, widgetFont);
+
+      RulerTool* r = getRulerToolCollection()->getActive();
+      if (r != nullptr) {
+          auto d = r->length();
+          sprintf(s, "%s: Length (mm) : %7.2f", r->metaData->name.c_str(), d);
+          posX = width() - widgetFontMetric.width(s)
+              - widgetFontMetric.width("00");
+          posY = height() - 4 * (widgetFontMetric.height() + 1);
+          this->renderText(posX, posY, s, widgetFont);
+      }
+      //QPainter painter(this);
+      //painter.setPen(Qt::blue);
+      //painter.drawLine(QLine(0, 0, 100, 100));
+      // if there is a selected/active ruler, then displace its length
+
+
+      getRulerToolCollection()->paint();
+      glDisable(GL_BLEND);
+  }
   else if( cValidOverlayData && cClickMode == CM_PAINT )
     {
     glEnable( GL_BLEND );
@@ -2107,6 +2199,108 @@ void QtGlSliceView::paintGL( void )
     }
 }
 
+QtGlSliceView::PointType2D QtGlSliceView::indexToScreenPoint(const PointType3D& index) {
+    double scale0 = this->width() / (double)cWinSizeX;
+    double scale1 = this->height() / (double)cWinSizeY;
+
+    double x, y;
+    if (isXFlipped()) {
+        x = -((index[cWinOrder[0]] - cWinMinX) * scale0 - width() + 1);
+    }
+    else {
+        x = (index[cWinOrder[0]] - cWinMinX) * scale0;
+    }
+
+
+    if (isYFlipped())
+    {
+        y = (index[cWinOrder[1]] - cWinMinY) * scale1;
+    }
+    else
+    {
+        y = -((index[cWinOrder[1]] - cWinMinY) * scale1 - height() + 1);
+    }
+
+    double p[2] = { x, y };
+    return PointType2D(p);
+}
+
+QtGlSliceView::PointType3D QtGlSliceView::screenPointToIndex(double x, double y) {
+    double scale0 = this->width() / (double)cWinSizeX;
+    double scale1 = this->height() / (double)cWinSizeY;
+    int originX = (int)(-cWinMinX * scale0);
+    if (originX < 0)
+    {
+        originX = 0;
+    }
+    int originY = (int)(-cWinMinY * scale1);
+    if (originY < 0)
+    {
+        originY = 0;
+    }
+ 
+    double p[3];
+    if (isXFlipped())
+    {
+        p[cWinOrder[0]] =
+            ((width() - 1 - x)) / scale0 + cWinMinX;
+    }
+    else
+    {
+        p[cWinOrder[0]] =
+            (x) / scale0 + cWinMinX;
+    }
+    if (p[cWinOrder[0]] < cWinMinX)
+    {
+        p[cWinOrder[0]] = cWinMinX;
+    }
+    if (p[cWinOrder[0]] > cWinMaxX)
+    {
+        p[cWinOrder[0]] = cWinMaxX;
+    }
+    if (isYFlipped())
+    {
+        p[cWinOrder[1]] =
+            (y) / scale1 + cWinMinY;
+    }
+    else
+    {
+        p[cWinOrder[1]] =
+            ((height() - 1 - y)) / scale1 + cWinMinY;
+    }
+    if (p[cWinOrder[1]] < cWinMinY)
+    {
+        p[cWinOrder[1]] = cWinMinY;
+    }
+    if (p[cWinOrder[1]] > cWinMaxY)
+    {
+        p[cWinOrder[1]] = cWinMaxY;
+    }
+    if (imageMode() != IMG_MIP)
+    {
+        p[cWinOrder[2]] = cWinCenter[cWinOrder[2]];
+    }
+    else
+    {
+        p[cWinOrder[2]] = cWinZBuffer[(int)p[cWinOrder[0]]
+            - cWinMinX
+            + ((int)p[cWinOrder[1]]
+                - cWinMinY)
+            * cWinDataSizeX];
+    }
+
+    return PointType3D(p);
+}
+
+QtGlSliceView::PointType3D QtGlSliceView::indexToPhysicalPoint(const PointType3D& indexPoint) {
+    itk::ContinuousIndex<double, 3> idx{ };
+    idx.SetElement(0, indexPoint[0]);
+    idx.SetElement(1, indexPoint[1]);
+    idx.SetElement(2, indexPoint[2]);
+    PointType3D ans{ };
+    this->cImData->TransformContinuousIndexToPhysicalPoint(idx, ans);
+    return ans;
+}
 
 void QtGlSliceView::mouseSelectEvent( QMouseEvent* mouseEvent )
 {
@@ -2115,82 +2309,24 @@ void QtGlSliceView::mouseSelectEvent( QMouseEvent* mouseEvent )
     return;
     }
 
-  double scale0 = this->width() / (double) cWinSizeX;
-  double scale1 = this->height() / (double) cWinSizeY;
-  int originX = (int)( -cWinMinX * scale0 );
-  if( originX < 0 )
-    {
-    originX = 0;
-    }
-  int originY = (int)( -cWinMinY * scale1 );
-  if( originY < 0 )
-    {
-    originY = 0;
-    }
+  if (cClickMode == CM_SELECT || cClickMode == CM_PAINT ||
+      cClickMode == CM_CUSTOM || cClickMode == CM_RULER)
+  {
+      auto p = screenPointToIndex(mouseEvent->x(), mouseEvent->y()).GetDataPointer();
 
-  if( cClickMode == CM_SELECT || cClickMode == CM_PAINT ||
-    cClickMode == CM_CUSTOM )
-    {
-    double p[3];
-
-    if( isXFlipped() )
+      if (cClickMode == CM_SELECT || cClickMode == CM_CUSTOM)
       {
-      p[cWinOrder[0]] =
-        ( (width()-1 - mouseEvent->x()) ) / scale0 + cWinMinX;
+          selectPoint(p[0], p[1], p[2]);
       }
-    else
+      if (cClickMode == CM_PAINT)
       {
-      p[cWinOrder[0]] =
-        ( mouseEvent->x() ) / scale0 + cWinMinX;
+          selectPoint(p[0], p[1], p[2]);
+          paintOverlayPoint(p[0], p[1], p[2]);
       }
-    if( p[cWinOrder[0]]<cWinMinX )
-      {
-      p[cWinOrder[0]] = cWinMinX;
+      if (cClickMode == CM_RULER) {
+          getRulerToolCollection()->handleMouseEvent(mouseEvent, p);
       }
-    if( p[cWinOrder[0]]>cWinMaxX )
-      {
-      p[cWinOrder[0]] = cWinMaxX;
-      }
-    if( isYFlipped() )
-      {
-      p[cWinOrder[1]] =
-        ( mouseEvent->y() ) / scale1 + cWinMinY;
-      }
-    else
-      {
-      p[cWinOrder[1]] =
-        ( (height()-1 - mouseEvent->y()) ) / scale1 + cWinMinY;
-      }
-    if( p[cWinOrder[1]]<cWinMinY )
-      {
-      p[cWinOrder[1]] = cWinMinY;
-      }
-    if( p[cWinOrder[1]]>cWinMaxY )
-      {
-      p[cWinOrder[1]] = cWinMaxY;
-      }
-    if( imageMode() != IMG_MIP )
-      {
-      p[cWinOrder[2]] = cWinCenter[cWinOrder[2]];
-      }
-    else
-      {
-      p[cWinOrder[2]] = cWinZBuffer[( int )p[cWinOrder[0]]
-                        - cWinMinX
-                       + ( ( int )p[cWinOrder[1]]
-                      - cWinMinY )
-                      * cWinDataSizeX];
-      }
-    if( cClickMode == CM_SELECT || cClickMode == CM_CUSTOM )
-      {
-      selectPoint( p[0], p[1], p[2] );
-      }
-    if( cClickMode == CM_PAINT )
-      {
-      selectPoint( p[0], p[1], p[2] );
-      paintOverlayPoint( p[0], p[1], p[2] );
-      }
-    }
+  }
   this->update();
 }
 
@@ -2209,12 +2345,18 @@ void QtGlSliceView::mousePressEvent( QMouseEvent* mouseEvent )
 void QtGlSliceView::mouseMoveEvent( QMouseEvent* mouseEvent )
 {
   cSelectMovement = SM_MOVE;
-  this->mouseSelectEvent( mouseEvent );
+  //printf("mouseMoveEvent");
+
+  // previous code didn't have mouse tracking enabled, but could handle mouse move events (i.e. when a button was held down)
+  if (cClickMode == CM_RULER || (mouseEvent->buttons() != Qt::NoButton) ) { // other modes don't handle moveEvents well
+      this->mouseSelectEvent(mouseEvent);
+  }
 }
 
 void QtGlSliceView::mouseReleaseEvent( QMouseEvent* mouseEvent )
 {
-  if( mouseEvent->button() & Qt::LeftButton )
+  // pass all ReleaseEvents if CM_RULER enabled
+  if( mouseEvent->button() & Qt::LeftButton || cClickMode == CM_RULER )
     {
     cSelectMovement = SM_RELEASE;
     this->mouseSelectEvent( mouseEvent );
@@ -2475,6 +2617,9 @@ void QtGlSliceView::zoomIn()
   update();
 }
 
+void QtGlSliceView::setInputImageFilepath(QString filepath) {
+    this->inputImageFilepath = filepath;
+}
 
 void QtGlSliceView::zoomOut()
 {
@@ -2516,6 +2661,21 @@ void QtGlSliceView::renderText( double x, double y, const QString & str,
     painter.drawPath( textPath );
     painter.end();
     }
+}
+
+RulerToolCollection* QtGlSliceView::getRulerToolCollection() {
+    auto axis_slice = std::pair<int, int>(cWinOrder[2], this->sliceNum());
+    if (cRulerCollections.find(axis_slice) == cRulerCollections.end()) {
+        std::unique_ptr< RulerToolCollection > rc(new RulerToolCollection(this, cCurrentRulerMetaFactory, cWinOrder[2], this->sliceNum())); // TODO: figure out which axis we're talking about (remove 2)
+        cRulerCollections[axis_slice] = std::move(rc);
+    }
+    return cRulerCollections[axis_slice].get();
+}
+
+void QtGlSliceView::setIsONSDRuler(bool flag) {
+    isONSDRuler = !isONSDRuler;
+    cCurrentRulerMetaFactory = isONSDRuler ? cONSDMetaFactory : cRainbowMetaFactory;
+    this->getRulerToolCollection()->setMetaDataFactory(cCurrentRulerMetaFactory);
 }
 
 #endif

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -33,6 +33,14 @@ limitations under the License.
 
 // ImageViewer includes
 #include "QtImageViewer_Export.h"
+#include "RulerWidget.h"
+
+#include <memory>
+
+class RulerToolCollection;
+class ONSDMetaDataGenerator;
+class RainbowMetaDataGenerator;
+class RulerToolMetaDataFactory;
 
 using namespace itk;
 
@@ -42,7 +50,7 @@ using namespace itk;
 *  PAINT = Color the overlay
 */
 const int NUM_ClickModeTypes = 4;
-typedef enum {CM_NOP, CM_SELECT, CM_CUSTOM, CM_PAINT} ClickModeType;
+typedef enum {CM_NOP, CM_SELECT, CM_CUSTOM, CM_PAINT, CM_RULER} ClickModeType;
 const char ClickModeTypeName[4][7] =
   {{'N', 'O', 'P', '\0', ' ', ' ', ' '},
   {'S', 'e', 'l', 'e', 'c', 't', '\0'},
@@ -161,7 +169,8 @@ public:
   typedef ImageType::IndexType    IndexType;
   typedef itk::ColorTable<double> ColorTableType;
   typedef ColorTableType::Pointer ColorTablePointer;
-
+  using PointType3D = itk::Point< double, 3 >;
+  using PointType2D = itk::Point< double, 2 >;
 public:
 
   QtGlSliceView(QWidget *parent = 0);
@@ -193,6 +202,11 @@ public:
   SelectMovementType selectMovement( void )
     { return cSelectMovement; };
 
+  PointType3D screenPointToIndex(double x, double y);
+
+  PointType2D indexToScreenPoint(const PointType3D& indexPoint);
+
+  PointType3D indexToPhysicalPoint(const PointType3D& indexPoint);
 
   /*! Get the opacity of the overlay */
   double overlayOpacity(void) const;
@@ -321,6 +335,8 @@ public:
   /// \sa maxDisplayStates, maxDisplayStates()
   void setMaxDisplayStates(int stateNumber);
 
+  void setInputImageFilepath(QString filepath);
+
 public slots:
   /// Set the displayState property value.
   /// \sa displayState, displayState()
@@ -363,6 +379,8 @@ public slots:
     { cOverlayPaintRadius = r; };
   void setPaintColor( int c )
     { cOverlayPaintColor = c; };
+
+  void saveRulers( void );
 
   void setIWModeMin(IWModeType newIWModeMin);
   void setIWModeMin(const char* mode);
@@ -439,6 +457,13 @@ public slots:
   void renderText(double x, double y, const QString & str,
     const QFont & font = QFont() );
 
+  /**
+  * Sets whether we are using the ONSD meta data for rulers or Rainbow (false).  Modifies the current
+  * RulerToolCollection if necessary.
+  * 
+  * \param flag
+  */
+  void setIsONSDRuler(bool flag);
 
 signals:
 
@@ -454,7 +479,7 @@ signals:
   void validOverlayDataChanged(bool valid);
   void maxClickedPointsStoredChanged(int max);
   void displayStateChanged(int state);
-
+  
 protected:
 
   void initializeGL();
@@ -511,6 +536,7 @@ protected:
   void (*cClickBoxArgCallBack)(double minX, double minY, double minZ,
                                double maxX, double maxY, double maxZ,
                                void * clickBoxArg);
+  RulerToolCollection* getRulerToolCollection();
 
   double cIWMin;
   double cIWMax;
@@ -575,6 +601,18 @@ protected:
   int cFastPace;
   int cFastMoveValue[3]; //fast moving pace
   double cFastIWValue[3]; //fast IW pace
+
+  
+  /**
+  * The file path of the currently viewed image
+  */
+  QString inputImageFilepath = "";
+  
+  bool isONSDRuler = false;
+  std::shared_ptr< RulerToolMetaDataFactory > cONSDMetaFactory;
+  std::shared_ptr< RulerToolMetaDataFactory > cRainbowMetaFactory;
+  std::shared_ptr< RulerToolMetaDataFactory > cCurrentRulerMetaFactory;
+  std::map< std::pair<int, int>, std::unique_ptr< RulerToolCollection > > cRulerCollections;
 };
   
 #endif

--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -275,11 +275,12 @@ void QtImageViewer::setOverlayImage(OverlayImageType* newImData)
 bool QtImageViewer::loadInputImage(QString filePathToLoad)
 {
   Q_D(QtImageViewer);
-
+  
   ImageType::Pointer image = d->loadImage<double>(filePathToLoad);
   if (image.IsNotNull())
     {
     this->setInputImage( image );
+    this->sliceView()->setInputImageFilepath(filePathToLoad);
     this->setWindowTitle(filePathToLoad);
     }
   return image.IsNotNull();

--- a/QtImageViewer/Resources/UI/QtImageViewer.ui
+++ b/QtImageViewer/Resources/UI/QtImageViewer.ui
@@ -55,7 +55,7 @@
         </sizepolicy>
        </property>
        <property name="mouseTracking">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="focusPolicy">
         <enum>Qt::WheelFocus</enum>

--- a/QtImageViewer/RulerWidget.cxx
+++ b/QtImageViewer/RulerWidget.cxx
@@ -1,0 +1,269 @@
+#include "RulerWidget.h"
+#include "QtGlSliceView.h"
+#include <Qt>
+#include <QtOpenGL/qgl.h>
+#include <QMouseEvent>
+#include <QGuiApplication>
+#include <cmath>
+#include "itkMath.h"
+
+bool operator< (std::unique_ptr< RulerToolMetaData > const& lhs, std::unique_ptr< RulerToolMetaData > const& rhs) {
+    return lhs->sortId < rhs->sortId;
+}
+
+RainbowMetaDataGenerator::RainbowMetaDataGenerator() { 
+    curColor = colors.begin(); 
+}
+
+std::unique_ptr< RulerToolMetaData > RainbowMetaDataGenerator::operator()(void) {
+    std::string name = std::to_string(curId);
+    QColor color = QColor(QString(curColor->c_str()));
+    int id = curId;
+
+    // wrap around to the beginning of the color list if at end
+    ++curColor;
+    if (curColor == colors.end()) {
+        curColor = colors.begin();
+    }
+
+    ++curId;
+    return std::unique_ptr< RulerToolMetaData >(new RulerToolMetaData{ id, name, color });
+}
+
+std::unique_ptr< RulerToolMetaData > ONSDMetaDataGenerator::operator()(void) {
+    std::string name = flipper ? "R1" : "ONSD";
+    QColor color = QColor(colors[(int)flipper].c_str());
+    int id = curId;
+
+    flipper = !flipper;
+    ++curId;
+
+    return std::unique_ptr< RulerToolMetaData >(new RulerToolMetaData{ id, name, color });
+}
+
+
+RulerToolMetaDataFactory::RulerToolMetaDataFactory(std::unique_ptr< MetaDataGenerator > generator) : generator{ std::move(generator) } { }
+
+std::unique_ptr< RulerToolMetaData > RulerToolMetaDataFactory::getNext() {
+    std::unique_ptr< RulerToolMetaData > ans;
+    if (refunds.size() > 0) {
+        ans = std::move(*(refunds.begin()));
+        refunds.erase(refunds.begin());
+    }
+    else {
+        ans = (*generator)();
+    }
+    return ans;
+}
+
+void RulerToolMetaDataFactory::refund(std::unique_ptr< RulerToolMetaData > ruler_meta) {
+    refunds.push_back(std::move(ruler_meta));
+    std::sort(refunds.begin(), refunds.end());
+}
+
+RulerTool::RulerTool(QtGlSliceView* parent0, PointType3D &index0, std::unique_ptr< RulerToolMetaData > metaData) :
+    parent{ parent0 }, indices{ index0, index0 }, points{ parent0->indexToPhysicalPoint(index0), parent0->indexToPhysicalPoint(index0) }, metaData{ std::move(metaData) }, clickRadius{ 10.0 }, state{ RulerToolState::drawing }, floatingIndex{ 1 }, crossStart{ 18 }, crossEnd{ 3 }, lineWidth{ 4 }
+{
+
+}
+
+RulerTool::~RulerTool() {}
+
+int RulerTool::isOver(double index[]) const {
+    int ans = -1;
+    auto screenPt = parent->indexToScreenPoint(PointType3D(index));
+    if (screenPt.EuclideanDistanceTo(parent->indexToScreenPoint(indices[0])) < clickRadius) {
+        ans = 0;
+    }
+    else if (screenPt.EuclideanDistanceTo(parent->indexToScreenPoint(indices[1])) < clickRadius) {
+        ans = 1;
+    }
+    return ans;
+}
+
+void RulerTool::updateFloatingIndex(double index[]) {
+    this->indices[this->floatingIndex] = PointType3D(index);
+    this->points[this->floatingIndex] = this->parent->indexToPhysicalPoint(index);
+}
+
+
+void RulerTool::setFloatingIndex(int id) {
+    this->floatingIndex = id;
+}
+
+int RulerTool::getFloatingIndex() const {
+    return this->floatingIndex;
+}
+
+double RulerTool::length() {
+    return this->points[0].EuclideanDistanceTo(this->points[1]);
+}
+
+void RulerTool::paint() { 
+
+    QPainter painter(this->parent);
+    QPen pen;
+
+    // could optimize this by memoization and catching parent stage changes
+    PointType2D screen0 = parent->indexToScreenPoint(indices[0]);
+    PointType2D screen1 = parent->indexToScreenPoint(indices[1]);
+
+    QColor color = metaData->color;
+    color.setAlphaF(0.7);
+    pen.setWidth(lineWidth);
+    pen.setColor(color);
+    painter.setPen(pen);
+
+    // TODO make line dotted
+
+    // crosshair1
+    painter.drawLine(QLine(screen0[0] - crossStart, screen0[1] - crossStart, screen0[0] - crossEnd, screen0[1] - crossEnd));
+    painter.drawLine(QLine(screen0[0] + crossStart, screen0[1] + crossStart, screen0[0] + crossEnd, screen0[1] + crossEnd));
+    painter.drawLine(QLine(screen0[0] - crossStart, screen0[1] + crossStart, screen0[0] - crossEnd, screen0[1] + crossEnd));
+    painter.drawLine(QLine(screen0[0] + crossStart, screen0[1] - crossStart, screen0[0] + crossEnd, screen0[1] - crossEnd));
+
+    // crosshair2
+    painter.drawLine(QLine(screen1[0] - crossStart, screen1[1] - crossStart, screen1[0] - crossEnd, screen1[1] - crossEnd));
+    painter.drawLine(QLine(screen1[0] + crossStart, screen1[1] + crossStart, screen1[0] + crossEnd, screen1[1] + crossEnd));
+    painter.drawLine(QLine(screen1[0] - crossStart, screen1[1] + crossStart, screen1[0] - crossEnd, screen1[1] + crossEnd));
+    painter.drawLine(QLine(screen1[0] + crossStart, screen1[1] - crossStart, screen1[0] + crossEnd, screen1[1] - crossEnd));
+
+    QPen pen2;
+    pen2.setWidth(lineWidth);
+    pen2.setColor(color);
+    pen2.setStyle(Qt::DashDotLine);
+    painter.setPen(pen2);
+
+    //line
+    painter.drawLine(QLine(screen0[0], screen0[1], screen1[0], screen1[1]));
+}
+
+std::string RulerTool::toJson() {
+    char txt[256];
+
+    int n = snprintf(txt, sizeof(txt),
+        "{ \"name\" : \"%s\", \"indices\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ], \"points\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ], \"distance\" : %.4f}",
+        metaData->name.c_str(),
+        indices[0].GetElement(0),
+        indices[0].GetElement(1),
+        indices[0].GetElement(2),
+        indices[1].GetElement(0),
+        indices[1].GetElement(1),
+        indices[1].GetElement(2),
+        points[0].GetElement(0),
+        points[0].GetElement(1),
+        points[0].GetElement(2),
+        points[1].GetElement(0),
+        points[1].GetElement(1),
+        points[1].GetElement(2),
+        points[0].EuclideanDistanceTo(points[1]));
+
+    if (n >= sizeof(txt)) {
+        throw "RulerTool::toJson tried to write too big of string";
+    }
+    return std::string(txt);
+}
+
+RulerToolCollection::RulerToolCollection(QtGlSliceView* parent, std::shared_ptr< RulerToolMetaDataFactory > metaDataFactory, unsigned short axis, unsigned int slice)
+    : parent{ parent }, metaDataFactory{ metaDataFactory }, axis{ axis }, slice{ slice }, currentId { -1 }, state { RulerToolState::standing }
+{
+
+}
+
+RulerToolCollection::~RulerToolCollection() {}
+
+void RulerToolCollection::handleMouseEvent(QMouseEvent* event, double index[]) {
+
+    int over = -1;
+    switch (this->state) {
+    case RulerToolState::standing:
+        over = isOver(index);
+        if (over >= 0) {
+            if (QGuiApplication::overrideCursor() == nullptr) {
+                QGuiApplication::setOverrideCursor(Qt::OpenHandCursor);
+            }
+            if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::RightButton) { // we're over a ruler and have right-clicked to move the crosshair
+                this->currentId = over;
+                RulerTool* r = rulers[currentId].get();
+                r->setFloatingIndex(r->isOver(index));
+                this->state = RulerToolState::drawing;
+                r->paint();
+            }
+        }
+        else {
+            QGuiApplication::restoreOverrideCursor();
+        }
+
+        // we're idle and we're clicking to create a new ruler
+        if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::LeftButton) {
+            // blank click on screen, make a ruler
+
+            std::unique_ptr< RulerTool > r(new RulerTool(this->parent, RulerTool::PointType3D(index), metaDataFactory->getNext()));
+            this->rulers.push_back(std::move(r));
+            this->currentId = this->rulers.size() - 1;
+            this->state = RulerToolState::drawing;
+            this->paint();
+        }
+        break;
+    case RulerToolState::drawing:
+        if (QGuiApplication::overrideCursor() != nullptr) {
+            QGuiApplication::restoreOverrideCursor(); // if we are drawing go back to a normal cursor, even if we're over a ruler
+        }
+        // we have one free end of the ruler and we are clicking to set it
+        if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::LeftButton) {
+            RulerTool* r = rulers[currentId].get();
+            r->updateFloatingIndex(index);
+            this->state = RulerToolState::standing;
+        }
+        // actively moving the free end
+        else if (event->type() == QEvent::MouseMove) {
+            RulerTool* r = rulers[currentId].get();
+            r->updateFloatingIndex(index);
+        }
+        else if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::RightButton) { // delete and go back to standing
+            metaDataFactory->refund(std::move(rulers[currentId]->metaData));
+            rulers.erase(rulers.begin() + currentId);
+            currentId = rulers.size() > 0 ? 0 : -1;
+            this->state = RulerToolState::standing;
+        }
+        break;
+    }
+
+}
+
+void RulerToolCollection::setMetaDataFactory(std::shared_ptr< RulerToolMetaDataFactory > factory) {
+    metaDataFactory = factory;
+}
+
+void RulerToolCollection::paint() {
+    for (auto &r : this->rulers) {
+        r->paint();
+    }
+}
+
+int RulerToolCollection::isOver(double index[]) {
+    for (int i=0; i < rulers.size(); ++i) {
+        auto r = rulers[i].get();
+        int x = r->isOver(index);
+        if (x >= 0) {
+            return i; // return the index of the ruler (different than RulerTool::isOver() which returns the index of the ruler point covered)
+        }
+    }
+    return -1;
+}
+
+RulerTool* RulerToolCollection::getActive() {
+    return currentId >= 0 ? rulers[currentId].get() : nullptr;
+}
+
+std::string RulerToolCollection::toJson() {
+    std::string ans = "{ \"axis\" : " + std::to_string(axis) + ", \"slice\" : " + std::to_string(slice) + ", \"rulers\" : [";
+    if (rulers.size() > 0) {
+        ans += rulers[0]->toJson();
+    }
+    for (auto iter = rulers.begin() + 1; iter != rulers.end(); ++iter) {
+        ans += "," + (*iter)->toJson();
+    }
+    ans += "]}";
+    return ans;
+}

--- a/QtImageViewer/RulerWidget.h
+++ b/QtImageViewer/RulerWidget.h
@@ -1,0 +1,266 @@
+/*=========================================================================
+
+Library:   TubeTK
+
+Copyright 2010 Kitware Inc. 28 Corporate Drive,
+Clifton Park, NY, 12065, USA.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
+#ifndef __RulerWidget_h
+#define __RulerWidget_h
+
+#include <vector>
+#include <memory>
+#include <functional>
+#include "itkImage.h"
+#include "itkPoint.h"
+#include <QOpenGLWidget>
+#include "QtGlSliceView.h"
+
+class QtGlSliceView; // cross-referencing due to the callbacks for the OpenGL painting
+
+
+enum class RulerToolState { 
+    standing = 0, /// not drawing anything, 
+    drawing = 1 /// one side of the ruler has been set, also covers repositioning a ruler
+};
+
+
+/**
+* RulerToolMetaData stores color, name, and a sorting id for a Ruler.  It allows for different workflows where defined
+* Rulers need to be specified.
+*/
+struct RulerToolMetaData {
+    /**
+    * Monotonically increasing ID.  Used to reset the workflow if a ruler or more is deleted.  I.e., if the ONSD
+    * requires a 3mm measurement, then the width, we don't want the user deleting the ONSD and measuring another
+    * 3mm.
+    */
+    int sortId;
+
+    /**
+    * Non-unique identifier for this ruler.
+    */
+    std::string name;
+
+    /**
+    * Color of ruler on-screen.
+    */
+    QColor color;
+};
+
+/**
+* Defined backwards so that this works with priority queue
+*/
+bool operator< (std::unique_ptr< RulerToolMetaData > const& lhs, std::unique_ptr< RulerToolMetaData > const& rhs); 
+
+/**
+* Functor for generating new meta data for newly created rulers.  Allows for rudimentary workflow.
+*/
+class MetaDataGenerator {
+public:
+    virtual std::unique_ptr< RulerToolMetaData > operator()(void) = 0;
+};
+
+/**
+* A looping set of 7 colors (ggplot color scheme) and increasing integer names.  Good default for generic workflows.
+*/
+class RainbowMetaDataGenerator : public MetaDataGenerator {
+public:
+    RainbowMetaDataGenerator();
+
+    std::unique_ptr< RulerToolMetaData > operator()(void);
+protected:
+    std::vector< std::string > colors = { "#F8766D", "#BB9D00", "#00B81F", "#00C0B8", "#00A5FF", "#E76BF3", "#FF6C90" };
+    std::vector< std::string >::iterator curColor;
+    int curId = 0;
+};
+
+/**
+* Two colors.  First ruler, "R1" should be the 3mm from ocular orb.  Second ruler, "ONSD" is the ONSD (optic nerve sheathe) measurment.  Names
+* are not unique, so rely on the positions and slices of the ruler to distinguish.
+*/
+class ONSDMetaDataGenerator : public MetaDataGenerator {
+public:
+    ONSDMetaDataGenerator() { };
+
+    std::unique_ptr< RulerToolMetaData > operator()(void);
+protected:
+    std::vector< std::string > colors = { "#F8766D", "#BB9D00" };
+    bool flipper = true;
+    int curId = 0;
+};
+
+
+/**
+* Factory class for meta data for new rulers.  Uses MetaDataGenerators.  Used to "refund" deleted rulers, i.e. if a user deletes a ruler
+* the next ruler they draw has the deleted meta data.
+* 
+* Suppose a user has drawn ONSD measurements (4 rulers) on two slices.  Now they have deleted 3 of the 4.  We want the next ruler they place
+* to be an ONSD from the still existing R1 measurement.  This isn't full-proof, but it works.
+*/
+class RulerToolMetaDataFactory {
+public:
+    RulerToolMetaDataFactory(std::unique_ptr< MetaDataGenerator > generator);
+
+    /**
+    * Get a the appropriate meta data for the next ruler.  Recycles deleted meta data.
+    */
+    std::unique_ptr< RulerToolMetaData > getNext();
+
+    /**
+    * Return a deleted meta data for reuse.
+    */
+    void refund(std::unique_ptr< RulerToolMetaData > ruler_meta);
+
+protected:
+    std::unique_ptr< MetaDataGenerator > generator;
+    std::vector< std::unique_ptr< RulerToolMetaData > > refunds;
+};
+
+/**
+* Stores and renders a ruler widget.  Note, it isn't a Qt widget as Qt doesn't like overlapping widgets.  Therefore,
+* this relies on the Qt Painter widgets rendering on the parent QOpenGLWidget.
+*/
+class RulerTool {
+public:
+
+    using PointType3D = itk::Point<double, 3>;
+    using PointType2D = itk::Point<double, 2>;
+
+    RulerTool() = delete;
+
+    /**
+    * \param parent QtGlSliceView
+    * \param index The image index location of first point of the ruler
+    * \param metaData metaData for the ruler
+    */
+    RulerTool(QtGlSliceView* parent, PointType3D& index, std::unique_ptr< RulerToolMetaData > metaData);
+    virtual ~RulerTool();
+
+    /**
+    * Whether the given image index is within the bounding box of one of the ruler ends
+    *
+    * \param index
+    * \return -1 for no, 0 or 1 identifies which end of the ruler was clicked
+    */
+    int isOver(double index[]) const;
+
+    /**
+    * The floating index is which end of the ruler (0 or 1) that is moving with the cursor.
+    * 
+    * \param id 0 or 1
+    */
+    void setFloatingIndex(int id);
+
+    /**
+    * The floating index is which end of the ruler (0 or 1) that is moving with the cursor.
+    */
+    int getFloatingIndex() const;
+    
+    /**
+    * Update the current floating index with the image index position.
+    * 
+    * \param index the image floating position
+    */
+    void updateFloatingIndex(double index[]);
+
+    /**
+    * Returns the Euclidean distance between the image physical points.
+    */
+    double length();
+
+    void paint();
+
+    std::unique_ptr< RulerToolMetaData > metaData;
+
+    /**
+    * Constructs JSON { name: "blargh", indices : [ [ x1, y1, z1 ], [ x2, y2, z2] ], points : [ [ x1, y1, z1 ], [ x2, y2, z2] ], distance : 0.3 } where distance is length()
+    */
+    std::string toJson();
+protected:
+    QtGlSliceView* parent;
+    int floatingIndex; // if we are drawing, what index is being moved
+    int crossStart; // defines how big the cross is in pixels
+    int crossEnd; // defines how big the empty middle of the cross is
+    int lineWidth; // how wide the cross and ruler lines
+
+    PointType3D points[2];
+    PointType3D indices[2];
+
+    float clickRadius; // how close to get to the cross points for the mouse handover
+    RulerToolState state;
+};
+
+
+/**
+* Represents a collection of Rulers drawn on a particular slice of an Image.  Currently set up to have a RulerToolCollection per z-slice.  An alternative would have been
+* one per entire image, but this makes the event handling a little easier.
+*
+* TODO : I don't really handle multiple generators well.  Weird things happen if you would toggle while drawing.
+*
+*/
+class RulerToolCollection {
+public:
+    /**
+    * \param parent the widget we're rendering in
+    * \param metaDataFactory factory to generate ruler color, name, etc
+    * \param axis which axis of the image slice corresponds to
+    * \param slice integer slice these rulers are draw on
+    */
+    RulerToolCollection(QtGlSliceView* parent, std::shared_ptr< RulerToolMetaDataFactory > metaDataFactory, unsigned short axis, unsigned int slice);
+    virtual ~RulerToolCollection();
+
+    /**
+    * Note, QtGlSliceView does all the computation to determine screen coordinate to image index space.  So we do a lot of image index space back
+    * to screen coordinates.
+    * 
+    * \param eventType
+    * \param index image index of mouse event
+    */
+    void handleMouseEvent(QMouseEvent* eventType, double index[]);
+    void paint();
+    RulerTool* getActive();
+    std::vector< std::unique_ptr< RulerTool > > rulers;
+
+    /**
+    * Constructs JSON { axis : axis_num, slice : slice_num, rulers : [ see rulers ] }
+    */
+    std::string toJson();
+
+    void setMetaDataFactory(std::shared_ptr< RulerToolMetaDataFactory > factory);
+
+protected:
+    QtGlSliceView* parent;
+   
+    /**
+    * Is the image index coordinate over any of the rulers in this collection.
+    * 
+    * \return -1 for no, otherwise, the index 0 - N of the ruler that contains index
+    */
+    int isOver(double index[]);
+
+    int currentId;
+    RulerToolState state;
+    unsigned short axis;
+    unsigned int slice;
+
+    std::shared_ptr< RulerToolMetaDataFactory > metaDataFactory;
+};
+
+
+#endif


### PR DESCRIPTION
Added a Ruler Widget that allows multiple rulers to be overlayed on an image and exported to JSON.

Added a new cClickMode CM_RULER.  Moved the screen to image index calculation in QtGlSliceView into its
own function and added the inverse and physical point transforms.

Added a new flag -R --ONSDRuler that changes the default ruler style to ONSD to the CLI app.

Added a new key input, 'u' that switches the ruler mode and ctrl-U that saves the ruler output to JSON.

Updated help information with usage.

Two modes to ruler, a "rainbow" mode that cycles between 7 colors and monotonically names each ruler and
a ONSD mode that has an "R1" and "ONSD" measure that is for the 3mm ocular orb distance and ONSD.

Rulers are placed with left-click and moved or deleted with right-click when in CM_RULER.

Use C++11 memory management features.