### PR TITLE
ENH: Save overlay on exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 #
 ##############################################################################
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10)
 
 project(ImageViewer)
 
@@ -57,6 +57,8 @@ endif(UNIX)
 
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
+
+find_package(VTK REQUIRED)
 
 find_package(Qt5 COMPONENTS Core Widgets Gui OpenGL REQUIRED)
 

--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -416,6 +416,7 @@ int parseAndExecImageViewer(int argc, char* argv[])
   viewer.sliceView()->setViewAxisLabel(axisLabel);
   viewer.sliceView()->setViewClickedPoints(clickedPoints);
   viewer.sliceView()->setImageMode(imageMode.c_str());
+  viewer.sliceView()->setSaveOverlayOnExit(saveOverlayOnExit.c_str());
   viewer.sliceView()->setIWModeMax(iwModeMax.c_str());
   viewer.sliceView()->setIWModeMin(iwModeMin.c_str());
   viewer.sliceView()->setClickSelectArgCallBack( myMouseCallback );
@@ -423,12 +424,27 @@ int parseAndExecImageViewer(int argc, char* argv[])
   viewer.sliceView()->setKeyEventArgCallBack( myKeyCallback );
   viewer.sliceView()->setKeyEventArg( (void*)(viewer.sliceView()) );
 
-  viewer.sliceView()->setPaintRadius( 10 );
-
   viewer.sliceView()->setIsONSDRuler(ONSDRuler);
 
-  //viewer.sliceView()->setPaintColor( 0 );
-  //viewer.sliceView()->setClickMode( CM_CUSTOM );
+  viewer.sliceView()->setPaintColor( paintColor );
+  viewer.sliceView()->setPaintRadius( paintRadius );
+
+  if( !strcmp(mouseMode.c_str(),"ConnComp") )
+    {
+    viewer.sliceView()->setClickMode( CM_CUSTOM );
+    }
+  else if( !strcmp(mouseMode.c_str(),"Paint") )
+    {
+    viewer.sliceView()->setClickMode( CM_PAINT );
+    }
+  else if( !strcmp(mouseMode.c_str(),"Ruler") )
+    {
+    viewer.sliceView()->setClickMode( CM_RULER );
+    }
+  else // if( !strcmp(mouseMode.c_str(),"Select") )
+    {
+    viewer.sliceView()->setClickMode( CM_SELECT );
+    }
 
 
   ImageType::Pointer img = viewer.sliceView()->inputImage();

--- a/ImageViewer/ImageViewer.xml
+++ b/ImageViewer/ImageViewer.xml
@@ -116,6 +116,22 @@
             <default>1</default>
             <description>Display details as an overlay on the image, inside a Controls Widget or turn it off.</description>
         </integer>
+        <integer>
+            <name>paintColor</name>
+            <flag>c</flag>
+            <longflag>paintColor</longflag>
+            <label>Paint Color</label>
+            <default>1</default>
+            <description>Initial paint color.</description>
+        </integer>
+        <integer>
+            <name>paintRadius</name>
+            <flag>r</flag>
+            <longflag>paintRadius</longflag>
+            <label>Paint Radius</label>
+            <default>10</default>
+            <description>Initial paint brush radius.</description>
+        </integer>
         <boolean>
             <name>physicalUnits</name>
             <flag>P</flag>
@@ -164,6 +180,17 @@
             <description>Toggle the mode as the data is viewed.</description>
         </string-enumeration>
         <string-enumeration>
+            <name>mouseMode</name>
+            <flag>M</flag>
+            <longflag>mouseMode</longflag>
+            <element>Select</element>
+            <element>ConnComp</element>
+            <element>Paint</element>
+            <element>Ruler</element>
+            <label>Mouse mode</label>
+            <description>Set the mouse click mode.</description>
+        </string-enumeration>
+        <string-enumeration>
             <name>iwModeMax</name>
             <flag>e</flag>
             <longflag>iwMax</longflag>
@@ -193,6 +220,14 @@
           <label>ONSD Ruler</label>
           <description>Set the default ruler (rainbow) to optic nerve sheathe diamter (ONSD)</description>
         </boolean>
+        <file>
+            <name>saveOverlayOnExit</name>
+            <flag>S</flag>
+            <longflag>saveOverlayOnExit</longflag>
+            <label>Save Overlay Image</label>
+            <default></default>
+            <description>Save Overlay Image to this file when program exits</description>
+        </file>
     </parameters>
 </executable>
 

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -2,8 +2,7 @@
 
 Library:   TubeTK
 
-Copyright 2010 Kitware Inc. 28 Corporate Drive,
-Clifton Park, NY, 12065, USA.
+Copyright Kitware Inc.
 
 All rights reserved.
 
@@ -161,6 +160,8 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
 
   cMessage = "";
 
+  cSaveOverlayOnExitFileName = "";
+
   cFastPace = 1;
   cFastMoveValue[0] = 0.5; //fast moving pace: 1 by defaut
   cFastMoveValue[1] = 1; //fast moving pace: 1 by defaut
@@ -173,9 +174,6 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   sP.setHeightForWidth( true );
   this->setSizePolicy( sP );
   
-  // this->setMouseTracking(true); // removed, set in the .ui file
-
- 
   cONSDMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< ONSDMetaDataGenerator >(new ONSDMetaDataGenerator())));
   cRainbowMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< RainbowMetaDataGenerator >(new RainbowMetaDataGenerator())));
 
@@ -183,6 +181,19 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
 
   cCurrentRulerMetaFactory = cRainbowMetaFactory;
   update();
+}
+
+QtGlSliceView::~QtGlSliceView()
+{
+  if( cSaveOverlayOnExitFileName.size() > 0 )
+    {
+    typedef itk::ImageFileWriter< OverlayType > WriterType;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName( cSaveOverlayOnExitFileName.toStdString() );
+    writer->SetInput( cOverlayData );
+    writer->SetUseCompression( true );
+    writer->Update();
+    }
 }
 
 
@@ -405,6 +416,11 @@ void QtGlSliceView::saveClickedPointsStored()
       << " : " << ( *point ).value << endl;
     }
   fpoints.close();
+}
+
+void QtGlSliceView::setSaveOverlayOnExit(const char * saveOverlayOnExitFileName )
+{
+  cSaveOverlayOnExitFileName = saveOverlayOnExitFileName;
 }
 
 void QtGlSliceView::saveRulers()

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -2,8 +2,7 @@
 
 Library:   TubeTK
 
-Copyright 2010 Kitware Inc. 28 Corporate Drive,
-Clifton Park, NY, 12065, USA.
+Copyright Kitware Inc.
 
 All rights reserved.
 
@@ -49,13 +48,14 @@ using namespace itk;
 *  SELECT = report pixel info
 *  PAINT = Color the overlay
 */
-const int NUM_ClickModeTypes = 4;
+const int NUM_ClickModeTypes = 5;
 typedef enum {CM_NOP, CM_SELECT, CM_CUSTOM, CM_PAINT, CM_RULER} ClickModeType;
-const char ClickModeTypeName[4][7] =
+const char ClickModeTypeName[5][7] =
   {{'N', 'O', 'P', '\0', ' ', ' ', ' '},
   {'S', 'e', 'l', 'e', 'c', 't', '\0'},
   {'C', 'u', 's', 't', 'o', 'm', '\0'},
-  {'P', 'a', 'i', 'n', 't', '\0', ' '}};
+  {'P', 'a', 'i', 'n', 't', '\0', ' '},
+  {'R', 'u', 'l', 'e', 'r', '\0', ' '}};
 
 /*! SelectMovementType encodes the type of SELECT event */
 const int NUM_SelectMovementTypes = 3;
@@ -174,6 +174,7 @@ public:
 public:
 
   QtGlSliceView(QWidget *parent = 0);
+  ~QtGlSliceView();
 
   virtual const ImagePointer & inputImage(void) const;
 
@@ -194,7 +195,13 @@ public:
     { cKeyEventArg = v; };
 
   void setClickMode( ClickModeType m )
-    { cClickMode = m; };
+    {
+    if (m != CM_SELECT && m != CM_NOP && !cValidOverlayData)
+      {
+      createOverlay();
+      }
+    cClickMode = m;
+    };
 
   ClickModeType clickMode( void )
     { return cClickMode; };
@@ -379,6 +386,8 @@ public slots:
     { cOverlayPaintRadius = r; };
   void setPaintColor( int c )
     { cOverlayPaintColor = c; };
+
+  void setSaveOverlayOnExit( const char* saveOverlayOnExitFileName );
 
   void saveRulers( void );
 
@@ -598,6 +607,8 @@ protected:
   int cMaxClickPoints;
 
   QString cMessage;
+
+  QString cSaveOverlayOnExitFileName;
 
   int cFastPace;
   int cFastMoveValue[3]; //fast moving pace

--- a/QtImageViewer/QtImageViewer.h
+++ b/QtImageViewer/QtImageViewer.h
@@ -2,8 +2,7 @@
 
 Library:   TubeTK
 
-Copyright 2010 Kitware Inc. 28 Corporate Drive,
-Clifton Park, NY, 12065, USA.
+Copyright Kitware Inc.
 
 All rights reserved.
 


### PR DESCRIPTION
New options to specify initial mouse mode (e.g., paint / select),
paint initial color, paint initial radius, and filename to auto save
overlay on exit.