### PR TITLE
Changes RulerTool constructor parameter to pass-by-value

### DIFF
--- a/QtImageViewer/RulerWidget.cxx
+++ b/QtImageViewer/RulerWidget.cxx
@@ -61,7 +61,7 @@ void RulerToolMetaDataFactory::refund(std::unique_ptr< RulerToolMetaData > ruler
     std::sort(refunds.begin(), refunds.end());
 }
 
-RulerTool::RulerTool(QtGlSliceView* parent0, PointType3D &index0, std::unique_ptr< RulerToolMetaData > metaData) :
+RulerTool::RulerTool(QtGlSliceView* parent0, PointType3D index0, std::unique_ptr< RulerToolMetaData > metaData) :
     parent{ parent0 }, indices{ index0, index0 }, points{ parent0->indexToPhysicalPoint(index0), parent0->indexToPhysicalPoint(index0) }, metaData{ std::move(metaData) }, clickRadius{ 10.0 }, state{ RulerToolState::drawing }, floatingIndex{ 1 }, crossStart{ 18 }, crossEnd{ 3 }, lineWidth{ 4 }
 {
 

--- a/QtImageViewer/RulerWidget.h
+++ b/QtImageViewer/RulerWidget.h
@@ -149,7 +149,7 @@ public:
     * \param index The image index location of first point of the ruler
     * \param metaData metaData for the ruler
     */
-    RulerTool(QtGlSliceView* parent, PointType3D& index, std::unique_ptr< RulerToolMetaData > metaData);
+    RulerTool(QtGlSliceView* parent, PointType3D index, std::unique_ptr< RulerToolMetaData > metaData);
     virtual ~RulerTool();
 
     /**

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This build should be relatively quick.
 
 *4) Qt5*
 
-Install Qt5 developer packages via qt.com or via apt-get.
+Install Qt5 developer packages via <qt.io> or via apt-get.
 
 *5) ImageViewer*
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This build should be relatively quick.
 
 *4) Qt5*
 
-Install Qt5 developer packages via <qt.io> or via apt-get.
+Install Qt5 developer packages via [qt.io](qt.io) or via apt-get.
 
 *5) ImageViewer*
 


### PR DESCRIPTION
I deleted ampersands in RulerWidget.cxx and RulerWidget.h so as to make the parameter "index0" in the RulerTool constructor pass-by-value instead of pass-by-reference. I also updated the README.md to display [qt.io](qt.io) instead of qt.com. 

Closes #91 
Closes #92 