### PR TITLE
ENH: ROI boxes and save-on-exit logic

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -415,7 +415,8 @@ int parseAndExecImageViewer(int argc, char* argv[])
   viewer.sliceView()->setViewAxisLabel(axisLabel);
   viewer.sliceView()->setViewClickedPoints(clickedPoints);
   viewer.sliceView()->setImageMode(imageMode.c_str());
-  viewer.sliceView()->setSaveOverlayOnExit(saveOverlayOnExit.c_str());
+  viewer.sliceView()->setSaveOnExitPrefix(saveOnExit.c_str());
+  viewer.sliceView()->setOverlayImageExtension(overlayImageExtension.c_str());
   viewer.sliceView()->setIWModeMax(iwModeMax.c_str());
   viewer.sliceView()->setIWModeMin(iwModeMin.c_str());
   viewer.sliceView()->setClickSelectArgCallBack( myMouseCallback );

--- a/ImageViewer/ImageViewer.xml
+++ b/ImageViewer/ImageViewer.xml
@@ -221,12 +221,19 @@
           <description>Set the default ruler (rainbow) to optic nerve sheathe diamter (ONSD)</description>
         </boolean>
         <file>
-            <name>saveOverlayOnExit</name>
+            <name>saveOnExit</name>
             <flag>S</flag>
-            <longflag>saveOverlayOnExit</longflag>
-            <label>Save Overlay Image</label>
+            <longflag>saveOnExit</longflag>
+            <label>Save Annotation</label>
             <default></default>
-            <description>Save Overlay Image to this file when program exits</description>
+            <description>Saves annotations (overlay, rulers, boxes) on exit with the specified file prefix.</description>
+        </file>
+        <file>
+            <name>overlayImageExtension</name>
+            <longflag>overlayImageExtension</longflag>
+            <label>Overlay Image Extension</label>
+            <default>mha</default>
+            <description>When saving the overlay image, use this image extension.</description>
         </file>
     </parameters>
 </executable>

--- a/QtImageViewer/BoxWidget.cxx
+++ b/QtImageViewer/BoxWidget.cxx
@@ -1,0 +1,256 @@
+#include "BoxWidget.h"
+#include "QtGlSliceView.h"
+#include <Qt>
+#include <QtOpenGL/qgl.h>
+#include <QMouseEvent>
+#include <QGuiApplication>
+#include <cmath>
+#include "itkMath.h"
+
+bool operator< (std::unique_ptr< BoxToolMetaData > const& lhs, std::unique_ptr< BoxToolMetaData > const& rhs) {
+    return lhs->sortId < rhs->sortId;
+}
+
+std::unique_ptr< BoxToolMetaData > ConstantBoxMetaDataGenerator::operator()(void) {
+    std::string name = std::to_string(curId);
+    QColor color = QColor(QString(constantColor.c_str()));
+    int id = curId;
+    ++curId;
+    return std::unique_ptr< BoxToolMetaData >(new BoxToolMetaData{ id, name, color });
+}
+
+
+BoxToolMetaDataFactory::BoxToolMetaDataFactory(std::unique_ptr< BoxMetaDataGenerator > generator) : generator{ std::move(generator) } { }
+
+std::unique_ptr< BoxToolMetaData > BoxToolMetaDataFactory::getNext() {
+    std::unique_ptr< BoxToolMetaData > ans;
+    if (refunds.size() > 0) {
+        ans = std::move(*(refunds.begin()));
+        refunds.erase(refunds.begin());
+    }
+    else {
+        ans = (*generator)();
+    }
+    return ans;
+}
+
+void BoxToolMetaDataFactory::refund(std::unique_ptr< BoxToolMetaData > box_meta) {
+    refunds.push_back(std::move(box_meta));
+    std::sort(refunds.begin(), refunds.end());
+}
+
+BoxTool::BoxTool(QtGlSliceView* parent0, PointType3D index0, std::unique_ptr< BoxToolMetaData > metaData) :
+    parent{ parent0 }, indices{ index0, index0 }, points{ parent0->indexToPhysicalPoint(index0), parent0->indexToPhysicalPoint(index0) }, metaData{ std::move(metaData) }, clickRadius{ 10.0 }, state{ BoxToolState::drawing }, floatingIndex{ 1 }, crossStart{ 18 }, crossEnd{ 3 }, lineWidth{ 4 }
+{
+
+}
+
+BoxTool::~BoxTool() {}
+
+int BoxTool::isOver(double index[]) const {
+    int ans = -1;
+    auto screenPt = parent->indexToScreenPoint(PointType3D(index));
+    if (screenPt.EuclideanDistanceTo(parent->indexToScreenPoint(indices[0])) < clickRadius) {
+        ans = 0;
+    }
+    else if (screenPt.EuclideanDistanceTo(parent->indexToScreenPoint(indices[1])) < clickRadius) {
+        ans = 1;
+    }
+    return ans;
+}
+
+void BoxTool::updateFloatingIndex(double index[]) {
+    this->indices[this->floatingIndex] = PointType3D(index);
+    this->points[this->floatingIndex] = this->parent->indexToPhysicalPoint(index);
+}
+
+
+void BoxTool::setFloatingIndex(int id) {
+    this->floatingIndex = id;
+}
+
+int BoxTool::getFloatingIndex() const {
+    return this->floatingIndex;
+}
+
+double BoxTool::area(int axis) {
+    // axis is one of X_AXIS, Y_AXIS, Z_AXIS, and assumes
+    // they correspond to 0, 1, 2 values.
+    int side1 = (axis + 1) % 3;
+    int side2 = (axis + 2) % 3;
+    return std::abs(
+        (this->points[0][side1] - this->points[1][side1]) *
+        (this->points[0][side2] - this->points[1][side2]));
+}
+
+void BoxTool::paint() {
+
+    QPainter painter(this->parent);
+    QPen pen;
+
+    // could optimize this by memoization and catching parent stage changes
+    PointType2D screen0 = parent->indexToScreenPoint(indices[0]);
+    PointType2D screen1 = parent->indexToScreenPoint(indices[1]);
+
+    QColor color = metaData->color;
+    color.setAlphaF(0.7);
+    pen.setWidth(lineWidth);
+    pen.setColor(color);
+    painter.setPen(pen);
+
+    // TODO make line dotted
+
+    // crosshair1
+    painter.drawLine(QLine(screen0[0] - crossStart, screen0[1] - crossStart, screen0[0] - crossEnd, screen0[1] - crossEnd));
+    painter.drawLine(QLine(screen0[0] + crossStart, screen0[1] + crossStart, screen0[0] + crossEnd, screen0[1] + crossEnd));
+    painter.drawLine(QLine(screen0[0] - crossStart, screen0[1] + crossStart, screen0[0] - crossEnd, screen0[1] + crossEnd));
+    painter.drawLine(QLine(screen0[0] + crossStart, screen0[1] - crossStart, screen0[0] + crossEnd, screen0[1] - crossEnd));
+
+
+    // crosshair2
+    painter.drawLine(QLine(screen1[0] - crossStart, screen1[1] - crossStart, screen1[0] - crossEnd, screen1[1] - crossEnd));
+    painter.drawLine(QLine(screen1[0] + crossStart, screen1[1] + crossStart, screen1[0] + crossEnd, screen1[1] + crossEnd));
+    painter.drawLine(QLine(screen1[0] - crossStart, screen1[1] + crossStart, screen1[0] - crossEnd, screen1[1] + crossEnd));
+    painter.drawLine(QLine(screen1[0] + crossStart, screen1[1] - crossStart, screen1[0] + crossEnd, screen1[1] - crossEnd));
+
+    QPen pen2;
+    pen2.setWidth(lineWidth);
+    pen2.setColor(color);
+    pen2.setStyle(Qt::DashDotLine);
+    painter.setPen(pen2);
+
+    // box
+    painter.drawLine(QLine(screen0[0], screen0[1], screen0[0], screen1[1]));
+    painter.drawLine(QLine(screen0[0], screen1[1], screen1[0], screen1[1]));
+    painter.drawLine(QLine(screen1[0], screen1[1], screen1[0], screen0[1]));
+    painter.drawLine(QLine(screen1[0], screen0[1], screen0[0], screen0[1]));
+}
+
+std::string BoxTool::toJson() {
+    char txt[256];
+
+    int n = snprintf(txt, sizeof(txt),
+        "{ \"name\" : \"%s\", \"indices\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ], \"points\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ]}",
+        metaData->name.c_str(),
+        indices[0].GetElement(0),
+        indices[0].GetElement(1),
+        indices[0].GetElement(2),
+        indices[1].GetElement(0),
+        indices[1].GetElement(1),
+        indices[1].GetElement(2),
+        points[0].GetElement(0),
+        points[0].GetElement(1),
+        points[0].GetElement(2),
+        points[1].GetElement(0),
+        points[1].GetElement(1),
+        points[1].GetElement(2));
+
+    if (n >= sizeof(txt)) {
+        throw "BoxTool::toJson tried to write too big of string";
+    }
+    return std::string(txt);
+}
+
+BoxToolCollection::BoxToolCollection(QtGlSliceView* parent, std::shared_ptr< BoxToolMetaDataFactory > metaDataFactory, unsigned short axis, unsigned int slice)
+    : parent{ parent }, metaDataFactory{ metaDataFactory }, axis{ axis }, slice{ slice }, currentId { -1 }, state { BoxToolState::standing }
+{
+
+}
+
+BoxToolCollection::~BoxToolCollection() {}
+
+void BoxToolCollection::handleMouseEvent(QMouseEvent* event, double index[]) {
+
+    int over = -1;
+    switch (this->state) {
+    case BoxToolState::standing:
+        over = isOver(index);
+        if (over >= 0) {
+            if (QGuiApplication::overrideCursor() == nullptr) {
+                QGuiApplication::setOverrideCursor(Qt::OpenHandCursor);
+            }
+            if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::RightButton) { // we're over a box and have right-clicked to move the crosshair
+                this->currentId = over;
+                BoxTool* r = boxes[currentId].get();
+                r->setFloatingIndex(r->isOver(index));
+                this->state = BoxToolState::drawing;
+                r->paint();
+            }
+        }
+        else {
+            QGuiApplication::restoreOverrideCursor();
+        }
+
+        // we're idle and we're clicking to create a new box
+        if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::LeftButton) {
+            // blank click on screen, make a box
+
+            std::unique_ptr< BoxTool > r(new BoxTool(this->parent, BoxTool::PointType3D(index), metaDataFactory->getNext()));
+            this->boxes.push_back(std::move(r));
+            this->currentId = this->boxes.size() - 1;
+            this->state = BoxToolState::drawing;
+            this->paint();
+        }
+        break;
+    case BoxToolState::drawing:
+        if (QGuiApplication::overrideCursor() != nullptr) {
+            QGuiApplication::restoreOverrideCursor(); // if we are drawing go back to a normal cursor, even if we're over a box
+        }
+        // we have one free end of the box and we are clicking to set it
+        if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::LeftButton) {
+            BoxTool* r = boxes[currentId].get();
+            r->updateFloatingIndex(index);
+            this->state = BoxToolState::standing;
+        }
+        // actively moving the free end
+        else if (event->type() == QEvent::MouseMove) {
+            BoxTool* r = boxes[currentId].get();
+            r->updateFloatingIndex(index);
+        }
+        else if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::RightButton) { // delete and go back to standing
+            metaDataFactory->refund(std::move(boxes[currentId]->metaData));
+            boxes.erase(boxes.begin() + currentId);
+            currentId = boxes.size() > 0 ? 0 : -1;
+            this->state = BoxToolState::standing;
+        }
+        break;
+    }
+
+}
+
+void BoxToolCollection::setMetaDataFactory(std::shared_ptr< BoxToolMetaDataFactory > factory) {
+    metaDataFactory = factory;
+}
+
+void BoxToolCollection::paint() {
+    for (auto &r : this->boxes) {
+        r->paint();
+    }
+}
+
+int BoxToolCollection::isOver(double index[]) {
+    for (int i=0; i < boxes.size(); ++i) {
+        auto r = boxes[i].get();
+        int x = r->isOver(index);
+        if (x >= 0) {
+            return i; // return the index of the box (different than BoxTool::isOver() which returns the index of the box point covered)
+        }
+    }
+    return -1;
+}
+
+BoxTool* BoxToolCollection::getActive() {
+    return currentId >= 0 ? boxes[currentId].get() : nullptr;
+}
+
+std::string BoxToolCollection::toJson() {
+    std::string ans = "{ \"axis\" : " + std::to_string(axis) + ", \"slice\" : " + std::to_string(slice) + ", \"boxes\" : [";
+    if (boxes.size() > 0) {
+        ans += boxes[0]->toJson();
+    }
+    for (auto iter = boxes.begin() + 1; iter != boxes.end(); ++iter) {
+        ans += "," + (*iter)->toJson();
+    }
+    ans += "]}";
+    return ans;
+}

--- a/QtImageViewer/BoxWidget.h
+++ b/QtImageViewer/BoxWidget.h
@@ -1,0 +1,248 @@
+/*=========================================================================
+
+Library:   TubeTK
+
+Copyright Kitware Inc.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
+#ifndef __BoxWidget_h
+#define __BoxWidget_h
+
+#include <vector>
+#include <memory>
+#include <functional>
+#include "itkImage.h"
+#include "itkPoint.h"
+#include <QOpenGLWidget>
+#include "QtGlSliceView.h"
+
+class QtGlSliceView; // cross-referencing due to the callbacks for the OpenGL painting
+
+
+enum class BoxToolState {
+    standing = 0, /// not drawing anything,
+    drawing = 1 /// one side of the box has been set, also covers repositioning a box
+};
+
+
+/**
+* BoxToolMetaData stores color, name, and a sorting id for a Box.  It allows for different workflows where defined
+* Boxes need to be specified.
+*/
+struct BoxToolMetaData {
+    /**
+    * Monotonically increasing ID.  Used to reset the workflow if a box or more is deleted.  I.e., if the ONSD
+    * requires a 3mm measurement, then the width, we don't want the user deleting the ONSD and measuring another
+    * 3mm.
+    */
+    int sortId;
+
+    /**
+    * Non-unique identifier for this box.
+    */
+    std::string name;
+
+    /**
+    * Color of box on-screen.
+    */
+    QColor color;
+};
+
+/**
+* Defined backwards so that this works with priority queue
+*/
+bool operator< (std::unique_ptr< BoxToolMetaData > const& lhs, std::unique_ptr< BoxToolMetaData > const& rhs);
+
+/**
+* Functor for generating new meta data for newly created boxes.  Allows for rudimentary workflow.
+*/
+class BoxMetaDataGenerator {
+public:
+    virtual std::unique_ptr< BoxToolMetaData > operator()(void) = 0;
+};
+
+/**
+* A constant set of colors and increasing integer names.
+*/
+class ConstantBoxMetaDataGenerator : public BoxMetaDataGenerator {
+public:
+    std::unique_ptr< BoxToolMetaData > operator()(void);
+protected:
+    const std::string constantColor = "#BB9D00";
+    int curId = 0;
+};
+
+/**
+* Factory class for meta data for new boxes.  Uses MetaDataGenerators.  Used to "refund" deleted boxes, i.e. if a user deletes a box
+* the next box they draw has the deleted meta data.
+*
+* Suppose a user has drawn ONSD measurements (4 boxes) on two slices.  Now they have deleted 3 of the 4.  We want the next box they place
+* to be an ONSD from the still existing R1 measurement.  This isn't full-proof, but it works.
+*/
+class BoxToolMetaDataFactory {
+public:
+    BoxToolMetaDataFactory(std::unique_ptr< BoxMetaDataGenerator > generator);
+
+    /**
+    * Get a the appropriate meta data for the next box.  Recycles deleted meta data.
+    */
+    std::unique_ptr< BoxToolMetaData > getNext();
+
+    /**
+    * Return a deleted meta data for reuse.
+    */
+    void refund(std::unique_ptr< BoxToolMetaData > box_meta);
+
+protected:
+    std::unique_ptr< BoxMetaDataGenerator > generator;
+    std::vector< std::unique_ptr< BoxToolMetaData > > refunds;
+};
+
+/**
+* Stores and renders a box widget.  Note, it isn't a Qt widget as Qt doesn't like overlapping widgets.  Therefore,
+* this relies on the Qt Painter widgets rendering on the parent QOpenGLWidget.
+*/
+class BoxTool {
+public:
+
+    using PointType3D = itk::Point<double, 3>;
+    using PointType2D = itk::Point<double, 2>;
+
+    BoxTool() = delete;
+
+    /**
+    * \param parent QtGlSliceView
+    * \param index The image index location of first point of the box
+    * \param metaData metaData for the box
+    */
+    BoxTool(QtGlSliceView* parent, PointType3D index, std::unique_ptr< BoxToolMetaData > metaData);
+    virtual ~BoxTool();
+
+    /**
+    * Whether the given image index is within the bounding box of one of the box ends
+    *
+    * \param index
+    * \return -1 for no, 0 or 1 identifies which end of the box was clicked
+    */
+    int isOver(double index[]) const;
+
+    /**
+    * The floating index is which end of the box (0 or 1) that is moving with the cursor.
+    *
+    * \param id 0 or 1
+    */
+    void setFloatingIndex(int id);
+
+    /**
+    * The floating index is which end of the box (0 or 1) that is moving with the cursor.
+    */
+    int getFloatingIndex() const;
+
+    /**
+    * Update the current floating index with the image index position.
+    *
+    * \param index the image floating position
+    */
+    void updateFloatingIndex(double index[]);
+
+    /**
+    * Returns the area of the box.
+    * An axis (X=0, Y=1, Z=2) must be specified because
+    * box coordinates are in 3D.
+    */
+    double area(int axis);
+
+    void paint();
+
+    std::unique_ptr< BoxToolMetaData > metaData;
+
+    /**
+    * Constructs JSON { name: "blargh", indices : [ [ x1, y1, z1 ], [ x2, y2, z2] ], points : [ [ x1, y1, z1 ], [ x2, y2, z2] ], distance : 0.3 } where distance is length()
+    */
+    std::string toJson();
+protected:
+    QtGlSliceView* parent;
+    int floatingIndex; // if we are drawing, what index is being moved
+    int crossStart; // defines how big the cross is in pixels
+    int crossEnd; // defines how big the empty middle of the cross is
+    int lineWidth; // how wide the cross and box lines
+
+    PointType3D points[2];
+    PointType3D indices[2];
+
+    float clickRadius; // how close to get to the cross points for the mouse handover
+    BoxToolState state;
+};
+
+
+/**
+* Represents a collection of Boxes drawn on a particular slice of an Image.  Currently set up to have a BoxToolCollection per z-slice.  An alternative would have been
+* one per entire image, but this makes the event handling a little easier.
+*
+* TODO : I don't really handle multiple generators well.  Weird things happen if you would toggle while drawing.
+*
+*/
+class BoxToolCollection {
+public:
+    /**
+    * \param parent the widget we're rendering in
+    * \param metaDataFactory factory to generate box color, name, etc
+    * \param axis which axis of the image slice corresponds to
+    * \param slice integer slice these boxes are draw on
+    */
+    BoxToolCollection(QtGlSliceView* parent, std::shared_ptr< BoxToolMetaDataFactory > metaDataFactory, unsigned short axis, unsigned int slice);
+    virtual ~BoxToolCollection();
+
+    /**
+    * Note, QtGlSliceView does all the computation to determine screen coordinate to image index space.  So we do a lot of image index space back
+    * to screen coordinates.
+    *
+    * \param eventType
+    * \param index image index of mouse event
+    */
+    void handleMouseEvent(QMouseEvent* eventType, double index[]);
+    void paint();
+    BoxTool* getActive();
+    std::vector< std::unique_ptr< BoxTool > > boxes;
+
+    /**
+    * Constructs JSON { axis : axis_num, slice : slice_num, boxes : [ see boxes ] }
+    */
+    std::string toJson();
+
+    void setMetaDataFactory(std::shared_ptr< BoxToolMetaDataFactory > factory);
+
+protected:
+    QtGlSliceView* parent;
+
+    /**
+    * Is the image index coordinate over any of the boxes in this collection.
+    *
+    * \return -1 for no, otherwise, the index 0 - N of the box that contains index
+    */
+    int isOver(double index[]);
+
+    int currentId;
+    BoxToolState state;
+    unsigned short axis;
+    unsigned int slice;
+
+    std::shared_ptr< BoxToolMetaDataFactory > metaDataFactory;
+};
+
+
+#endif

--- a/QtImageViewer/CMakeLists.txt
+++ b/QtImageViewer/CMakeLists.txt
@@ -39,6 +39,7 @@ set( QtImageViewer_SRCS
   QtGlSliceView.cxx
   QtImageViewer.cxx
   RulerWidget.cxx
+  BoxWidget.cxx
   )
 
 set( QtImageViewer_GUI_SRCS
@@ -49,6 +50,7 @@ set( QtImageViewer_MOC_SRCS
   QtGlSliceView.h
   QtImageViewer.h
   RulerWidget.h
+  BoxWidget.h
   )
 
 add_library( QtImageViewer STATIC ${QtImageViewer_SRCS}

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -181,6 +181,9 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   isONSDRuler = false;
 
   cCurrentRulerMetaFactory = cRainbowMetaFactory;
+
+  cCurrentBoxMetaFactory = std::shared_ptr< BoxToolMetaDataFactory >(new BoxToolMetaDataFactory(std::unique_ptr< ConstantBoxMetaDataGenerator >(new ConstantBoxMetaDataGenerator())));
+
   update();
 }
 
@@ -471,6 +474,37 @@ void QtGlSliceView::saveRulers()
             auto& rc = node.second;
             std::string sep = isFirst ? "" : ",";
             if (node.second->rulers.size() > 0) {
+                text << sep.c_str() << rc->toJson().c_str();
+                isFirst = false;
+            }
+    }
+    text << "]}";
+    fpoints.close();
+}
+
+void QtGlSliceView::saveBoxes()
+{
+    QFileInfo fileInfo(this->inputImageFilepath);
+    QString newFilepath = fileInfo.path() + "/" + fileInfo.completeBaseName() + ".boxes.json";
+    QString fileName = QFileDialog::getSaveFileName(this,
+        "Save box measurements", newFilepath, "*.*");
+    if (fileName.isNull())
+    {
+        return;
+    }
+    QFile fpoints(fileName);
+    if (!fpoints.open(QIODevice::ReadWrite | QIODevice::Truncate)) // write and overwrite
+    {
+        return;
+    }
+    QTextStream text(&fpoints);
+    text << "{ \"boxes\" : [";
+    bool isFirst = true;
+    for (auto& node : cBoxCollections)
+    {
+            auto& rc = node.second;
+            std::string sep = isFirst ? "" : ",";
+            if (node.second->boxes.size() > 0) {
                 text << sep.c_str() << rc->toJson().c_str();
                 isFirst = false;
             }
@@ -926,7 +960,7 @@ void QtGlSliceView::showHelp()
     str << QString("         - Blend with previous and next slice");
     str << QString("         - MIP");
     str << QString("    ");
-    str << QString("   \\ - cycle between mouse Modes: Select Points, Custom, Ruler, Paint");
+    str << QString("   \\ - cycle between mouse Modes: Select Points, Custom, Ruler, Box, Paint");
     str << QString("        - Default Custom is threshold connected components");
     str << QString("    ");
     str << QString("   Paint mode: ");
@@ -937,7 +971,7 @@ void QtGlSliceView::showHelp()
     str << QString("   Image processing ");
     str << QString("   \' - Perform median filtering with radius=1");
     str << QString("    ");
-    str << QString("   Ruler Measurements ");
+    str << QString("   Ruler/Box Measurements ");
     str << QString("   Left click to set ruler.  Right-click over X to move or delete");
     str << QString("   u - Toggle between rainbow ruler and ONSD measurements");
     str << QString("   ctrl-U - Save measurements to JSON");
@@ -1517,6 +1551,14 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
             {
                 createOverlay();
             }
+            cClickMode = CM_BOX;
+            update();
+        }
+        else if ( cClickMode == CM_BOX ) {
+            if (!cValidOverlayData)
+            {
+                createOverlay();
+            }
             cClickMode = CM_PAINT;
             update();
         }
@@ -1579,6 +1621,9 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
             else {
                 setIsONSDRuler(!isONSDRuler);
             }
+        }
+        else if (cClickMode == CM_BOX && keyEvent->modifiers() & Qt::CTRL) {
+          saveBoxes();
         }
         break;
     case Qt::Key_E:
@@ -2074,6 +2119,30 @@ void QtGlSliceView::paintGL( void )
       getRulerToolCollection()->paint();
       glDisable(GL_BLEND);
   }
+  else if (cClickMode == CM_BOX)
+  {
+      glEnable(GL_BLEND);
+      glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+      glColor4f(0.1, 0.64, 0.2, (double)0.75);
+      char s[80];
+      sprintf(s, "BOX: Box Widget");
+      int posX = width() - widgetFontMetric.width(s)
+          - widgetFontMetric.width("00");
+      int posY = height() - 2 * (widgetFontMetric.height() + 1);
+      this->renderText(posX, posY, s, widgetFont);
+
+      BoxTool* b = getBoxToolCollection()->getActive();
+      if (b != nullptr) {
+          auto a = b->area(cWinOrder[2]);
+          sprintf(s, "%s: Area (mm^3) : %7.2f", b->metaData->name.c_str(), a);
+          posX = width() - widgetFontMetric.width(s)
+              - widgetFontMetric.width("00");
+          posY = height() - 4 * (widgetFontMetric.height() + 1);
+          this->renderText(posX, posY, s, widgetFont);
+      }
+      getBoxToolCollection()->paint();
+      glDisable(GL_BLEND);
+  }
   else if( cValidOverlayData && cClickMode == CM_PAINT )
     {
     glEnable( GL_BLEND );
@@ -2353,7 +2422,8 @@ void QtGlSliceView::mouseSelectEvent( QMouseEvent* mouseEvent )
     }
 
   if (cClickMode == CM_SELECT || cClickMode == CM_PAINT ||
-      cClickMode == CM_CUSTOM || cClickMode == CM_RULER)
+      cClickMode == CM_CUSTOM || cClickMode == CM_RULER ||
+      cClickMode == CM_BOX)
   {
       auto p = screenPointToIndex(mouseEvent->x(), mouseEvent->y()).GetDataPointer();
 
@@ -2368,6 +2438,9 @@ void QtGlSliceView::mouseSelectEvent( QMouseEvent* mouseEvent )
       }
       if (cClickMode == CM_RULER) {
           getRulerToolCollection()->handleMouseEvent(mouseEvent, p);
+      }
+      if (cClickMode == CM_BOX) {
+          getBoxToolCollection()->handleMouseEvent(mouseEvent, p);
       }
   }
   this->update();
@@ -2391,7 +2464,11 @@ void QtGlSliceView::mouseMoveEvent( QMouseEvent* mouseEvent )
   //printf("mouseMoveEvent");
 
   // previous code didn't have mouse tracking enabled, but could handle mouse move events (i.e. when a button was held down)
-  if (cClickMode == CM_RULER || (mouseEvent->buttons() != Qt::NoButton) ) { // other modes don't handle moveEvents well
+  if (
+    cClickMode == CM_RULER ||
+    cClickMode == CM_BOX ||
+    (mouseEvent->buttons() != Qt::NoButton)
+  ) { // other modes don't handle moveEvents well
       this->mouseSelectEvent(mouseEvent);
   }
 }
@@ -2399,7 +2476,7 @@ void QtGlSliceView::mouseMoveEvent( QMouseEvent* mouseEvent )
 void QtGlSliceView::mouseReleaseEvent( QMouseEvent* mouseEvent )
 {
   // pass all ReleaseEvents if CM_RULER enabled
-  if( mouseEvent->button() & Qt::LeftButton || cClickMode == CM_RULER )
+  if( mouseEvent->button() & Qt::LeftButton || cClickMode == CM_RULER || cClickMode == CM_BOX)
     {
     cSelectMovement = SM_RELEASE;
     this->mouseSelectEvent( mouseEvent );
@@ -2713,6 +2790,15 @@ RulerToolCollection* QtGlSliceView::getRulerToolCollection() {
         cRulerCollections[axis_slice] = std::move(rc);
     }
     return cRulerCollections[axis_slice].get();
+}
+
+BoxToolCollection* QtGlSliceView::getBoxToolCollection() {
+    auto axis_slice = std::pair<int, int>(cWinOrder[2], this->sliceNum());
+    if (cBoxCollections.find(axis_slice) == cBoxCollections.end()) {
+        std::unique_ptr< BoxToolCollection > rc(new BoxToolCollection(this, cCurrentBoxMetaFactory, cWinOrder[2], this->sliceNum())); // TODO: figure out which axis we're talking about (remove 2)
+        cBoxCollections[axis_slice] = std::move(rc);
+    }
+    return cBoxCollections[axis_slice].get();
 }
 
 void QtGlSliceView::setIsONSDRuler(bool flag) {

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -34,13 +34,16 @@ limitations under the License.
 // ImageViewer includes
 #include "QtImageViewer_Export.h"
 #include "RulerWidget.h"
+#include "BoxWidget.h"
 
 #include <memory>
 
 class RulerToolCollection;
+class BoxToolCollection;
 class ONSDMetaDataGenerator;
 class RainbowMetaDataGenerator;
 class RulerToolMetaDataFactory;
+class BoxToolMetaDataFactory;
 
 using namespace itk;
 
@@ -50,13 +53,14 @@ using namespace itk;
 *  PAINT = Color the overlay
 */
 const int NUM_ClickModeTypes = 5;
-typedef enum {CM_NOP, CM_SELECT, CM_CUSTOM, CM_PAINT, CM_RULER} ClickModeType;
-const char ClickModeTypeName[5][7] =
+typedef enum {CM_NOP, CM_SELECT, CM_CUSTOM, CM_PAINT, CM_RULER, CM_BOX} ClickModeType;
+const char ClickModeTypeName[6][7] =
   {{'N', 'O', 'P', '\0', ' ', ' ', ' '},
   {'S', 'e', 'l', 'e', 'c', 't', '\0'},
   {'C', 'u', 's', 't', 'o', 'm', '\0'},
   {'P', 'a', 'i', 'n', 't', '\0', ' '},
-  {'R', 'u', 'l', 'e', 'r', '\0', ' '}};
+  {'R', 'u', 'l', 'e', 'r', '\0', ' '},
+  {'B', 'o', 'x', '\0', ' ', ' ', ' '}};
 
 /*! SelectMovementType encodes the type of SELECT event */
 const int NUM_SelectMovementTypes = 3;
@@ -391,6 +395,7 @@ public slots:
   void setSaveOverlayOnExit( const char* saveOverlayOnExitFileName );
 
   void saveRulers( void );
+  void saveBoxes( void );
 
   void setIWModeMin(IWModeType newIWModeMin);
   void setIWModeMin(const char* mode);
@@ -548,6 +553,7 @@ protected:
                                double maxX, double maxY, double maxZ,
                                void * clickBoxArg);
   RulerToolCollection* getRulerToolCollection();
+  BoxToolCollection* getBoxToolCollection();
 
   double cIWMin;
   double cIWMax;
@@ -626,7 +632,9 @@ protected:
   std::shared_ptr< RulerToolMetaDataFactory > cONSDMetaFactory;
   std::shared_ptr< RulerToolMetaDataFactory > cRainbowMetaFactory;
   std::shared_ptr< RulerToolMetaDataFactory > cCurrentRulerMetaFactory;
+  std::shared_ptr< BoxToolMetaDataFactory > cCurrentBoxMetaFactory;
   std::map< std::pair<int, int>, std::unique_ptr< RulerToolCollection > > cRulerCollections;
+  std::map< std::pair<int, int>, std::unique_ptr< BoxToolCollection > > cBoxCollections;
 };
   
 #endif

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -385,17 +385,21 @@ public slots:
 
   void setOverlay(bool newOverlay);
   void createOverlay( void );
-  void saveOverlay( void );
+  void saveOverlayWithPrompt( void );
+  void saveOverlay( std::string fileName );
   void paintOverlayPoint( double x, double y, double z );
   void setPaintRadius( int r )
     { cOverlayPaintRadius = r; };
   void setPaintColor( int c )
     { cOverlayPaintColor = c; };
+  void setOverlayImageExtension( const char* ext );
 
-  void setSaveOverlayOnExit( const char* saveOverlayOnExitFileName );
+  void setSaveOnExitPrefix( const char* prefix );
 
-  void saveRulers( void );
-  void saveBoxes( void );
+  void saveRulersWithPrompt( void );
+  void saveRulers( std::string fileName );
+  void saveBoxesWithPrompt( void );
+  void saveBoxes( std::string fileName );
 
   void setIWModeMin(IWModeType newIWModeMin);
   void setIWModeMin(const char* mode);
@@ -511,6 +515,7 @@ protected:
   double cOverlayOpacity;
   int cOverlayPaintRadius;
   int cOverlayPaintColor;
+  QString cOverlayImageExtension;
 
   OverlayPointer cOverlayData;
 
@@ -615,7 +620,7 @@ protected:
 
   QString cMessage;
 
-  QString cSaveOverlayOnExitFileName;
+  QString cSaveOnExitPrefix;
 
   int cFastPace;
   int cFastMoveValue[3]; //fast moving pace


### PR DESCRIPTION
- ROI box widget is now available.
- Save-on-exit logic extends to saving everything (rulers, overlays, boxes).

The `-S` option is now named "saveOnExit". This takes a filename prefix which, when ImageViewer exits, is used to determine the final filename for saved annotations. In addition, there is a new option `--overlayImageExtension` which takes in a valid image extension, e.g. "nrrd". The default is "mha".
- for overlays, the filename is `prefix + ".overlay." + overlayImageExtension`
- for rulers/boxes, the filename is `prefix + ".[rulers|boxes].json"`.