### PR TITLE
ENH: Read in box annotations

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -507,6 +507,12 @@ int parseAndExecImageViewer(int argc, char* argv[])
     viewer.sliceView()->switchWorkflowStep(0);
   }
 
+  for (auto fileName : jsonAnnotationFiles) {
+    if (!viewer.loadJSONAnnotations(QString::fromStdString(fileName))) {
+      std::cerr << "Could not load annotations from " << fileName << std::endl;
+    }
+  }
+
   ImageType::Pointer img = viewer.sliceView()->inputImage();
 
   typedef itk::StatisticsImageFilter<ImageType>  StatisticsFilterType;

--- a/ImageViewer/ImageViewer.xml
+++ b/ImageViewer/ImageViewer.xml
@@ -236,6 +236,13 @@
             <default>mha</default>
             <description>When saving the overlay image, use this image extension.</description>
         </file>
+        <file multiple="true">
+            <name>jsonAnnotationFiles</name>
+            <flag>n</flag>
+            <longflag>jsonAnnotation</longflag>
+            <label>Load JSON Annotation</label>
+            <description>Loads annotations from a JSON file.</description>
+        </file>
         <string-vector>
           <name>workflow</name>
           <flag>w</flag>

--- a/QtImageViewer/BoxWidget.cxx
+++ b/QtImageViewer/BoxWidget.cxx
@@ -72,7 +72,6 @@ void BoxTool::updateFloatingIndex(double index[]) {
     this->points[this->floatingIndex] = this->parent->indexToPhysicalPoint(index);
 }
 
-
 void BoxTool::setFloatingIndex(int id) {
     this->floatingIndex = id;
 }
@@ -193,8 +192,7 @@ void BoxToolCollection::handleMouseEvent(QMouseEvent* event, double index[]) {
         if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::LeftButton) {
             // blank click on screen, make a box
 
-            std::unique_ptr< BoxTool > r(new BoxTool(this->parent, BoxTool::PointType3D(index), metaDataFactory->getNext()));
-            this->boxes.push_back(std::move(r));
+            this->createBox(index);
             this->currentId = this->boxes.size() - 1;
             this->state = BoxToolState::drawing;
             this->paint();
@@ -224,6 +222,20 @@ void BoxToolCollection::handleMouseEvent(QMouseEvent* event, double index[]) {
         break;
     }
 
+}
+
+BoxTool* BoxToolCollection::createBox(double point1[]) {
+  std::unique_ptr< BoxTool > b(new BoxTool(this->parent, BoxTool::PointType3D(point1), metaDataFactory->getNext()));
+  auto boxTool = b.get();
+  this->boxes.push_back(std::move(b));
+  return boxTool;
+}
+
+BoxTool* BoxToolCollection::createBox(double point1[], double point2[]) {
+  auto b = this->createBox(point1);
+  b->setFloatingIndex(1);
+  b->updateFloatingIndex(point2);
+  return b;
 }
 
 void BoxToolCollection::setMetaDataFactory(std::shared_ptr< BoxToolMetaDataFactory > factory) {

--- a/QtImageViewer/BoxWidget.h
+++ b/QtImageViewer/BoxWidget.h
@@ -80,7 +80,8 @@ public:
 */
 class ConstantBoxMetaDataGenerator : public BoxMetaDataGenerator {
 public:
-    ConstantBoxMetaDataGenerator() : ConstantBoxMetaDataGenerator("", 1) {}
+    // default color to yellow
+    ConstantBoxMetaDataGenerator() : ConstantBoxMetaDataGenerator("", 0xffffff00) {}
     ConstantBoxMetaDataGenerator(std::string name, QColor color) : mName(name), mColor(color) {}
     std::unique_ptr< BoxToolMetaData > operator()(void);
 protected:
@@ -210,6 +211,18 @@ public:
     BoxToolCollection(QtGlSliceView* parent, std::shared_ptr< BoxToolMetaDataFactory > metaDataFactory, unsigned short axis, unsigned int slice);
     virtual ~BoxToolCollection();
 
+    /**
+    * Creates a box. Only sets one corner.
+    * \param point1 the top left 3d point (in image index space)
+    * \param point2 the bottom right 3d point (in image index space)
+    */
+    BoxTool* createBox(double point1[]);
+    /**
+    * Creates a box.
+    * \param point1 the top left 3d point (in image index space)
+    * \param point2 the bottom right 3d point (in image index space)
+    */
+    BoxTool* createBox(double point1[], double point2[]);
     /**
     * Note, QtGlSliceView does all the computation to determine screen coordinate to image index space.  So we do a lot of image index space back
     * to screen coordinates.

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -2253,10 +2253,11 @@ void QtGlSliceView::paintGL( void )
     glDisable( GL_BLEND );
     }
 
-  // always paint boxes
-  glEnable(GL_BLEND);
-  getBoxToolCollection()->paint();
-  glDisable(GL_BLEND);
+  if (this->viewOverlayData()) {
+    glEnable(GL_BLEND);
+    getBoxToolCollection()->paint();
+    glDisable(GL_BLEND);
+  }
 
   if( cWorkflowSteps.size() != 0 ) {
     glEnable( GL_BLEND );

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -522,6 +522,16 @@ public slots:
   */
   void setIsONSDRuler(bool flag);
 
+  /**
+  * Adds a box.
+  * \param name name of the box
+  * \param axis placed axis
+  * \param slice the slice number
+  * \param point1 top left of box
+  * \param point2 bottom right of box
+  */
+  void addBox(std::string name, int axis, int slice, double point1[], double point2[]);
+
 
 signals:
 
@@ -600,6 +610,7 @@ protected:
                                void * clickBoxArg);
   RulerToolCollection* getRulerToolCollection();
   BoxToolCollection* getBoxToolCollection();
+  BoxToolCollection* getBoxToolCollection(int axis, int sliceNum);
 
   double cIWMin;
   double cIWMax;

--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -28,6 +28,9 @@ limitations under the License.
 #include <QMessageBox>
 #include <QSlider>
 #include <QTimer>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 
 // QtImageViewer includes
 #include "QtImageViewer.h"
@@ -297,6 +300,81 @@ bool QtImageViewer::loadOverlayImage(QString filePathToLoad)
     this->setOverlayImage( image );
     }
   return image.IsNotNull();
+}
+
+bool QtImageViewer::loadJSONAnnotations(QString filePathToLoad)
+{
+  Q_D(QtImageViewer);
+
+  QFile file(filePathToLoad);
+  if (!file.open(QIODevice::ReadOnly)) {
+    return false;
+  }
+
+  const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+  file.close();
+
+  if (doc.isNull() || doc.isEmpty() || !doc.isObject()) {
+    return false;
+  }
+
+  bool status = false;
+
+  const QJsonObject root = doc.object();
+  if (root.contains("boxes") && root["boxes"].isArray()) {
+    const QJsonArray slices = root["boxes"].toArray();
+    for (auto val1 : slices) {
+      if (val1.isObject()) {
+        const QJsonObject slice = val1.toObject();
+        if (
+          slice.contains("axis") && slice["axis"].isDouble() &&
+          slice.contains("slice") && slice["slice"].isDouble() &&
+          slice.contains("boxes") && slice["boxes"].isArray()
+        ) {
+          const int axis = (int)slice["axis"].toDouble();
+          const int sliceNum = (int)slice["slice"].toDouble();
+          const QJsonArray boxes = slice["boxes"].toArray();
+          for (auto val2 : boxes) {
+            if (val2.isObject()) {
+              const QJsonObject box = val2.toObject();
+              if (
+                box.contains("name") && box["name"].isString() &&
+                box.contains("indices") && box["indices"].isArray()
+              ) {
+                const QString name = box["name"].toString();
+                const QJsonArray indices = box["indices"].toArray();
+                if (
+                  indices.size() == 2 &&
+                  indices[0].isArray() &&
+                  indices[1].isArray()
+                ) {
+                  const QJsonArray pt1Array = indices[0].toArray();
+                  const QJsonArray pt2Array = indices[1].toArray();
+                  if (pt1Array.size() == 3 && pt2Array.size() == 3) {
+                    double point1[] = {
+                      pt1Array[0].toDouble(),
+                      pt1Array[1].toDouble(),
+                      pt1Array[2].toDouble(),
+                    };
+                    double point2[] = {
+                      pt2Array[0].toDouble(),
+                      pt2Array[1].toDouble(),
+                      pt2Array[2].toDouble(),
+                    };
+                    this->sliceView()->addBox(name.toStdString(), axis, sliceNum, point1, point2);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    status = true;
+  }
+
+  return status;
 }
 
 void QtImageViewer::keyPressEvent(QKeyEvent* keyEvent)

--- a/QtImageViewer/QtImageViewer.h
+++ b/QtImageViewer/QtImageViewer.h
@@ -59,6 +59,9 @@ public slots:
   //// \sa loadInputImage(), setOverlayImage()
   bool loadOverlayImage(QString filePath = QString());
 
+  /// Load a JSON annotation file.
+  bool loadJSONAnnotations(QString filePath = QString());
+
   /// Set the image to view.
   /// \sa setOverlayImage(), loadInputImage()
   virtual void setInputImage(ImageType * newImData);


### PR DESCRIPTION
This adds a switch `-n` to read in box annotations and display them. Specifying multiple `-n` switches will read in multiple annotation files.

Other fixes:
- boxes now show even if the mode is not on box widget

Notes:
- the changes do not allow for reading in ruler annotations yet