### PR TITLE
Add ruler workflow

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -497,9 +497,29 @@ int parseAndExecImageViewer(int argc, char* argv[])
         step->factory = factory;
 
         steps.push_back(std::move(step));
-        
-      }else {
-        throw std::runtime_error("Use p, P, b, B for this switch");
+
+      }
+      else if (type == "r" || type == "R")
+      {
+        auto generator = std::unique_ptr<RulerMetaDataGenerator>();
+        if (i < workflow.size() && workflow[i] == "o")
+        {
+          i++;
+          generator = std::unique_ptr<RulerMetaDataGenerator>(new ONSDRulerMetaDataGenerator());
+        }else
+        {
+          generator = std::unique_ptr<RulerMetaDataGenerator>(new RainbowRulerMetaDataGenerator());
+        }
+
+        std::shared_ptr<RulerToolMetaDataFactory> factory(new RulerToolMetaDataFactory(std::move(generator)));
+
+        std::unique_ptr<RulerStep> step(new RulerStep());
+        step->factory = factory;
+
+        steps.push_back(std::move(step));
+      }else
+      {
+        throw std::runtime_error("Use p, P, b, B, r, R for this switch");
       }
     }
 

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -1371,8 +1371,12 @@ void QtGlSliceView::switchWorkflowStep( int index )
     auto boxStep = static_cast<BoxStep*>(step.get());
     auto collection = getBoxToolCollection();
     collection->setMetaDataFactory(boxStep->factory);
+  } else if (step->type == CM_RULER) {
+    setClickMode(CM_RULER);
+    auto rulerStep = static_cast<RulerStep *>(step.get());
+    auto collection = getRulerToolCollection();
+    collection->setMetaDataFactory(rulerStep->factory);
   }
-
 }
 
 void QtGlSliceView::paintOverlayPoint( double x, double y, double z )
@@ -2283,8 +2287,13 @@ void QtGlSliceView::paintGL( void )
         auto boxStep = static_cast<BoxStep*>(step.get());
 
         sprintf( s, "STEP: %d (BOX), L: %s", cWorkflowIndex, boxStep->name.c_str());
-      }
+      } else if (step->type == CM_RULER)
+      {
 
+        auto rulerStep = static_cast<RulerStep*>(step.get());
+
+        sprintf(s, "STEP: %d (RULER)", cWorkflowIndex);
+      }
 
     int posX = width() - widgetFontMetric.width(s)
       - widgetFontMetric.width("00");

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -179,8 +179,8 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   sP.setHeightForWidth( true );
   this->setSizePolicy( sP );
   
-  cONSDMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< ONSDMetaDataGenerator >(new ONSDMetaDataGenerator())));
-  cRainbowMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< RainbowMetaDataGenerator >(new RainbowMetaDataGenerator())));
+  cONSDMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< ONSDRulerMetaDataGenerator >(new ONSDRulerMetaDataGenerator())));
+  cRainbowMetaFactory = std::shared_ptr< RulerToolMetaDataFactory >(new RulerToolMetaDataFactory(std::unique_ptr< RainbowRulerMetaDataGenerator >(new RainbowRulerMetaDataGenerator())));
 
   isONSDRuler = false;
 

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -145,6 +145,16 @@ struct BoxStep : Step {
   std::shared_ptr< BoxToolMetaDataFactory > factory;
 };
 
+/*! Ruler box step.
+* name: name of the box
+*/
+
+struct RulerStep : Step
+{
+  RulerStep() : Step(CM_RULER) {}
+  std::shared_ptr<RulerToolMetaDataFactory> factory;
+};
+
 /**
 * QtGlSliceView : Derived from abstract class SliceView and Fl_Gl_Window
 * See SliceView.h for details...

--- a/QtImageViewer/RulerWidget.cxx
+++ b/QtImageViewer/RulerWidget.cxx
@@ -11,11 +11,11 @@ bool operator< (std::unique_ptr< RulerToolMetaData > const& lhs, std::unique_ptr
     return lhs->sortId < rhs->sortId;
 }
 
-RainbowMetaDataGenerator::RainbowMetaDataGenerator() { 
+RainbowRulerMetaDataGenerator::RainbowRulerMetaDataGenerator() { 
     curColor = colors.begin(); 
 }
 
-std::unique_ptr< RulerToolMetaData > RainbowMetaDataGenerator::operator()(void) {
+std::unique_ptr< RulerToolMetaData > RainbowRulerMetaDataGenerator::operator()(void) {
     std::string name = std::to_string(curId);
     QColor color = QColor(QString(curColor->c_str()));
     int id = curId;
@@ -30,7 +30,7 @@ std::unique_ptr< RulerToolMetaData > RainbowMetaDataGenerator::operator()(void) 
     return std::unique_ptr< RulerToolMetaData >(new RulerToolMetaData{ id, name, color });
 }
 
-std::unique_ptr< RulerToolMetaData > ONSDMetaDataGenerator::operator()(void) {
+std::unique_ptr< RulerToolMetaData > ONSDRulerMetaDataGenerator::operator()(void) {
     std::string name = flipper ? "R1" : "ONSD";
     QColor color = QColor(colors[(int)flipper].c_str());
     int id = curId;
@@ -42,7 +42,7 @@ std::unique_ptr< RulerToolMetaData > ONSDMetaDataGenerator::operator()(void) {
 }
 
 
-RulerToolMetaDataFactory::RulerToolMetaDataFactory(std::unique_ptr< MetaDataGenerator > generator) : generator{ std::move(generator) } { }
+RulerToolMetaDataFactory::RulerToolMetaDataFactory(std::unique_ptr< RulerMetaDataGenerator > generator) : generator{ std::move(generator) } { }
 
 std::unique_ptr< RulerToolMetaData > RulerToolMetaDataFactory::getNext() {
     std::unique_ptr< RulerToolMetaData > ans;

--- a/QtImageViewer/RulerWidget.h
+++ b/QtImageViewer/RulerWidget.h
@@ -70,7 +70,7 @@ bool operator< (std::unique_ptr< RulerToolMetaData > const& lhs, std::unique_ptr
 /**
 * Functor for generating new meta data for newly created rulers.  Allows for rudimentary workflow.
 */
-class MetaDataGenerator {
+class RulerMetaDataGenerator {
 public:
     virtual std::unique_ptr< RulerToolMetaData > operator()(void) = 0;
 };
@@ -78,9 +78,9 @@ public:
 /**
 * A looping set of 7 colors (ggplot color scheme) and increasing integer names.  Good default for generic workflows.
 */
-class RainbowMetaDataGenerator : public MetaDataGenerator {
+class RainbowRulerMetaDataGenerator : public RulerMetaDataGenerator {
 public:
-    RainbowMetaDataGenerator();
+    RainbowRulerMetaDataGenerator();
 
     std::unique_ptr< RulerToolMetaData > operator()(void);
 protected:
@@ -93,9 +93,9 @@ protected:
 * Two colors.  First ruler, "R1" should be the 3mm from ocular orb.  Second ruler, "ONSD" is the ONSD (optic nerve sheathe) measurment.  Names
 * are not unique, so rely on the positions and slices of the ruler to distinguish.
 */
-class ONSDMetaDataGenerator : public MetaDataGenerator {
+class ONSDRulerMetaDataGenerator : public RulerMetaDataGenerator {
 public:
-    ONSDMetaDataGenerator() { };
+    ONSDRulerMetaDataGenerator() { };
 
     std::unique_ptr< RulerToolMetaData > operator()(void);
 protected:
@@ -106,7 +106,7 @@ protected:
 
 
 /**
-* Factory class for meta data for new rulers.  Uses MetaDataGenerators.  Used to "refund" deleted rulers, i.e. if a user deletes a ruler
+* Factory class for meta data for new rulers.  Uses RulerMetaDataGenerators.  Used to "refund" deleted rulers, i.e. if a user deletes a ruler
 * the next ruler they draw has the deleted meta data.
 * 
 * Suppose a user has drawn ONSD measurements (4 rulers) on two slices.  Now they have deleted 3 of the 4.  We want the next ruler they place
@@ -114,7 +114,7 @@ protected:
 */
 class RulerToolMetaDataFactory {
 public:
-    RulerToolMetaDataFactory(std::unique_ptr< MetaDataGenerator > generator);
+    RulerToolMetaDataFactory(std::unique_ptr< RulerMetaDataGenerator > generator);
 
     /**
     * Get a the appropriate meta data for the next ruler.  Recycles deleted meta data.
@@ -127,7 +127,7 @@ public:
     void refund(std::unique_ptr< RulerToolMetaData > ruler_meta);
 
 protected:
-    std::unique_ptr< MetaDataGenerator > generator;
+    std::unique_ptr< RulerMetaDataGenerator > generator;
     std::vector< std::unique_ptr< RulerToolMetaData > > refunds;
 };
 


### PR DESCRIPTION
Adds a ruler workflow, similar to the paint and bounding box workflows.

Workflow string is "r" or "R", and users can optionally specify "o" for the onsd measurement specific features.