### PR TITLE
ENH: add preserveOverlayPaint flag

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -426,6 +426,7 @@ int parseAndExecImageViewer(int argc, char* argv[])
   viewer.sliceView()->setClickSelectArg( (void*)(viewer.sliceView()) );
   viewer.sliceView()->setKeyEventArgCallBack( myKeyCallback );
   viewer.sliceView()->setKeyEventArg( (void*)(viewer.sliceView()) );
+  viewer.sliceView()->setFixedSliceMoveValue( fixedSliceDelta );
 
   viewer.sliceView()->setIsONSDRuler(ONSDRuler);
 

--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -429,6 +429,7 @@ int parseAndExecImageViewer(int argc, char* argv[])
 
   viewer.sliceView()->setIsONSDRuler(ONSDRuler);
 
+  viewer.sliceView()->setPreserveOverlayPaint( preserveOverlayPaint );
   viewer.sliceView()->setPaintColor( paintColor );
   viewer.sliceView()->setPaintRadius( paintRadius );
 

--- a/ImageViewer/ImageViewer.xml
+++ b/ImageViewer/ImageViewer.xml
@@ -258,6 +258,13 @@
           <label>Workflow Steps</label>
           <default></default>
         </string-vector>
+        <integer>
+          <name>fixedSliceDelta</name>
+          <longflag>fixedSliceDelta</longflag>
+          <description>A positive integer that fixes the number of slices to jump by when scrolling slices. Disables the "f" key functionality.</description>
+          <label>Fixed Slice Delta</label>
+          <default>0</default>
+        </integer>
     </parameters>
 </executable>
 

--- a/ImageViewer/ImageViewer.xml
+++ b/ImageViewer/ImageViewer.xml
@@ -116,6 +116,13 @@
             <default>1</default>
             <description>Display details as an overlay on the image, inside a Controls Widget or turn it off.</description>
         </integer>
+        <boolean>
+            <name>preserveOverlayPaint</name>
+            <longflag>preserveOverlayPaint</longflag>
+            <default>false</default>
+            <label>Preserve overlay paint</label>
+            <description>When enabled, new paint will never overwrite existing paint.</description>
+        </boolean>
         <integer>
             <name>paintColor</name>
             <flag>c</flag>

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -59,6 +59,7 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   cValidOverlayData     = false;
   cViewOverlayData      = false;
   cOverlayOpacity       = 0.75;
+  cPreserveOverlayPaint = false;
   cOverlayPaintRadius   = 2;
   cOverlayPaintColor    = 1;
   cWinOverlayData       = NULL;
@@ -1445,7 +1446,14 @@ void QtGlSliceView::paintOverlayPoint( double x, double y, double z )
         if( z2 + y2 + x2 <= r2 )
           {
           idx[0] = ix;
-          cOverlayData->SetPixel( idx, c );
+          if(
+            c == 0 || // allow eraser
+            !cPreserveOverlayPaint || // no preserve
+            cOverlayData->GetPixel( idx ) == 0 // preserve labeled pixels
+          )
+            {
+            cOverlayData->SetPixel( idx, c );
+            }
           }
         }
       }

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -60,6 +60,7 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   cViewOverlayData      = false;
   cOverlayOpacity       = 0.75;
   cPreserveOverlayPaint = false;
+  cFixedSliceMoveValue  = 0;
   cOverlayPaintRadius   = 2;
   cOverlayPaintColor    = 1;
   cWinOverlayData       = NULL;
@@ -1579,6 +1580,10 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
     case Qt::Key_Less: // <
     case Qt::Key_Comma:
         movePace = cFastMoveValue[cFastPace];
+        if( cFixedSliceMoveValue > 0 )
+        {
+          movePace = cFixedSliceMoveValue;
+        }
         if ((int)cWinCenter[cWinOrder[2]] - movePace < 0)
         {
             if ((int)cWinCenter[cWinOrder[2]] == 0)
@@ -1685,6 +1690,10 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
     case Qt::Key_Period:
       //when pressing down ">" or "<" key, scrolling will go faster
       movePace = cFastMoveValue[ cFastPace ];
+      if( cFixedSliceMoveValue > 0 )
+      {
+        movePace = cFixedSliceMoveValue;
+      }
       if( ( int )cWinCenter[cWinOrder[2]]+movePace >=
           ( int )cDimSize[cWinOrder[2]]-1 )
         {

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -436,6 +436,8 @@ public slots:
   void saveOverlayWithPrompt( void );
   void saveOverlay( std::string fileName );
   void paintOverlayPoint( double x, double y, double z );
+  void setPreserveOverlayPaint( bool preserve )
+    { cPreserveOverlayPaint = preserve; };
   void setPaintRadius( int r )
     { cOverlayPaintRadius = r; };
   void setPaintColor( int c )
@@ -570,6 +572,7 @@ protected:
   int cDisplayState;
   int cMaxDisplayStates;
   bool cValidOverlayData;
+  bool cPreserveOverlayPaint;
   double cOverlayOpacity;
   int cOverlayPaintRadius;
   int cOverlayPaintColor;

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -443,6 +443,8 @@ public slots:
   void setPaintColor( int c )
     { cOverlayPaintColor = c; };
   void setOverlayImageExtension( const char* ext );
+  void setFixedSliceMoveValue( int delta )
+    { cFixedSliceMoveValue = delta; }
 
   void setSaveOnExitPrefix( const char* prefix );
 
@@ -577,6 +579,7 @@ protected:
   int cOverlayPaintRadius;
   int cOverlayPaintColor;
   QString cOverlayImageExtension;
+  int cFixedSliceMoveValue;
 
   std::vector<std::unique_ptr<struct Step>> cWorkflowSteps;
   int cWorkflowIndex;


### PR DESCRIPTION
Adds `--preserveOverlayPaint`, which will prevent overwriting already painted voxels.