### PR TITLE
Interpolate paint overlay across slices

### DIFF
--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -333,7 +333,6 @@ QtGlSliceView
   if( !cValidImData || newoverlay_size[2]==cImData_size[2] )
     {
     cOverlayData = newOverlayData;
-
     cViewOverlayData  = true;
     cValidOverlayData = true;
 
@@ -1357,6 +1356,13 @@ void QtGlSliceView::createOverlay( void )
   this->setInputOverlay( cOverlayData );
 }
 
+void QtGlSliceView::interpolateOverlay ()
+{
+  MciType::Pointer mci = MciType::New();
+  mci->SetInput( cOverlayData );
+  mci->Update();
+  cOverlayData = mci->GetOutput();
+}
 
 void QtGlSliceView::switchWorkflowStep( int index ) 
 {
@@ -1396,7 +1402,7 @@ void QtGlSliceView::paintOverlayPoint( double x, double y, double z, std::string
 
   int r = cOverlayPaintRadius;
   int c = cOverlayPaintColor;
-
+  
   if (QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
     c = 0;
   }
@@ -1608,8 +1614,11 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
         if( cFixedSliceMoveValue > 0 )
         {
           movePace = cFixedSliceMoveValue;
-          cWorkflowIndex = 0;
-          switchWorkflowStep(cWorkflowIndex);
+          if( cWorkflowSteps.size() != 0 ) 
+          {
+            cWorkflowIndex = 0;
+            switchWorkflowStep(cWorkflowIndex);
+          } 
         }
         if ((int)cWinCenter[cWinOrder[2]] - movePace < 0)
         {
@@ -1728,8 +1737,11 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
       if( cFixedSliceMoveValue > 0 )
       {
         movePace = cFixedSliceMoveValue;
-        cWorkflowIndex = 0;
-        switchWorkflowStep(cWorkflowIndex);
+        if( cWorkflowSteps.size() != 0 ) 
+        {
+          cWorkflowIndex = 0;
+          switchWorkflowStep(cWorkflowIndex);
+        }
       }
       if( ( int )cWinCenter[cWinOrder[2]]+movePace >=
           ( int )cDimSize[cWinOrder[2]]-1 )
@@ -1964,6 +1976,14 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
         {
         setViewValuePhysicalUnits( !viewValuePhysicalUnits() );
         }
+      else if (keyEvent->modifiers() & Qt::CTRL)
+      {
+        if (!cValidOverlayData)
+        {
+          createOverlay();
+        }
+        interpolateOverlay();
+      }
       else
         {
         saveClickedPointsStored();

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -67,8 +67,8 @@ QtGlSliceView::QtGlSliceView( QWidget* widgetParent )
   cWinOverlayData       = NULL;
   cOverlayImageExtension = "mha";
 
-  interp_start_slice = -1;
-  interp_end_slice = -1;
+  cInterpStartSlice = -1;
+  cInterpEndSlice = -1;
 
   cWorkflowIndex        = 0;
 
@@ -1902,7 +1902,7 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
       int newY;
       if (keyEvent->modifiers() & Qt::ShiftModifier)
         {
-        interp_start_slice = sliceNum();
+        cInterpStartSlice = sliceNum();
         }
       else if( isYFlipped() )
         {
@@ -1940,12 +1940,19 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
           {
           createOverlay();
           }
-        interp_end_slice = sliceNum();
-        if (interp_start_slice != -1 && interp_end_slice != -1)
+        cInterpEndSlice = sliceNum();
+        if (cInterpStartSlice != -1 && cInterpEndSlice != -1 && cInterpStartSlice != cInterpEndSlice)
           {
-          interpolateOverlay(interp_start_slice, interp_end_slice);
-          }  
-        }
+          if (cInterpStartSlice > cInterpEndSlice)
+            {
+            int tmp = cInterpEndSlice;
+            cInterpEndSlice = cInterpStartSlice;
+            cInterpStartSlice = tmp;
+            }
+          interpolateOverlay(cInterpStartSlice, cInterpEndSlice);
+          cInterpStartSlice = cInterpEndSlice;
+          cInterpEndSlice = -1;
+          }
       else if( isXFlipped() )
         {
         newX = cWinCenter[cWinOrder[0]]+imgShiftSize;

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -592,8 +592,8 @@ protected:
   int cOverlayPaintColor;
   QString cOverlayImageExtension;
   int cFixedSliceMoveValue;
-  int interp_start_slice;
-  int interp_end_slice;
+  int cInterpStartSlice;
+  int cInterpEndSlice;
 
   std::vector<std::unique_ptr<struct Step>> cWorkflowSteps;
   int cWorkflowIndex;

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -30,6 +30,7 @@ limitations under the License.
 // ITK includes
 #include "itkImage.h"
 #include "itkColorTable.h"
+#include "itkMorphologicalContourInterpolator.h"
 
 // ImageViewer includes
 #include "QtImageViewer_Export.h"
@@ -53,7 +54,7 @@ using namespace itk;
 *  SELECT = report pixel info
 *  PAINT = Color the overlay
 */
-const int NUM_ClickModeTypes = 5;
+const int NUM_ClickModeTypes = 7;
 typedef enum {CM_NOP, CM_SELECT, CM_CUSTOM, CM_PAINT3D, CM_PAINT2D, CM_RULER, CM_BOX} ClickModeType;
 const char ClickModeTypeName[7][9] =
   {{'N', 'O', 'P', '\0', ' ', ' ', ' ', ' ', ' '},
@@ -222,6 +223,7 @@ public:
   typedef ImageType::RegionType   RegionType;
   typedef ImageType::SizeType     SizeType;
   typedef ImageType::IndexType    IndexType;
+  typedef itk::MorphologicalContourInterpolator<OverlayType> MciType;
   typedef itk::ColorTable<double> ColorTableType;
   typedef ColorTableType::Pointer ColorTablePointer;
   using PointType3D = itk::Point< double, 3 >;
@@ -441,6 +443,7 @@ public slots:
 
   void setOverlay(bool newOverlay);
   void createOverlay( void );
+  void interpolateOverlay( void );
   void saveOverlayWithPrompt( void );
   void saveOverlay( std::string fileName );
   void paintOverlayPoint( double x, double y, double z, std::string dimension);

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -216,6 +216,7 @@ public:
   typedef QOpenGLWidget                        Superclass;
   typedef double                           ImagePixelType;
   typedef unsigned char                    OverlayPixelType;
+  typedef long int                         IndexValueType;
   typedef itk::Image<ImagePixelType,3>     ImageType;
   typedef itk::Image<OverlayPixelType,3>   OverlayType;
   typedef ImageType::Pointer      ImagePointer;
@@ -443,7 +444,7 @@ public slots:
 
   void setOverlay(bool newOverlay);
   void createOverlay( void );
-  void interpolateOverlay( void );
+  void interpolateOverlay( int start, int stop );
   void saveOverlayWithPrompt( void );
   void saveOverlay( std::string fileName );
   void paintOverlayPoint( double x, double y, double z, std::string dimension);
@@ -591,6 +592,8 @@ protected:
   int cOverlayPaintColor;
   QString cOverlayImageExtension;
   int cFixedSliceMoveValue;
+  int interp_start_slice;
+  int interp_end_slice;
 
   std::vector<std::unique_ptr<struct Step>> cWorkflowSteps;
   int cWorkflowIndex;


### PR DESCRIPTION
Hi All,

I've added a feature that uses ITK's Morphological Contour Interpolator to interpolate paint overlays across slices. Paint slice X and jump a bunch of slices and paint slice Y. Then hit Ctrl + P for the interpolation. The slices that were not painted in between will be filled in.

Kindly review the changes and let me know if there are modifications needed here.

Thank you,
Barry