### PR TITLE
ENH: Add persistent workflows and one level of undo

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -459,6 +459,19 @@ int parseAndExecImageViewer(int argc, char* argv[])
     viewer.sliceView()->setClickMode( CM_SELECT );
     }
 
+  bool usePersistentWorkflow = false;
+  if(workflowPersistent.size() >= 1)
+    {
+    if(workflow.size() >= 1)
+      {
+      std::cerr << "Cannot specify both a workflow and a persistentWorkflow"
+        << std::endl;
+      return EXIT_FAILURE;
+      }
+    workflow = std::move(workflowPersistent);
+    usePersistentWorkflow = true;
+    }
+
   if (workflow.size() >= 1) {
 
     std::vector<std::unique_ptr<struct Step>> steps;
@@ -544,6 +557,7 @@ int parseAndExecImageViewer(int argc, char* argv[])
 
     viewer.sliceView()->setWorkflowSteps(std::move(steps));
     viewer.sliceView()->switchWorkflowStep(0);
+    viewer.sliceView()->setUsePersistentWorkflow(usePersistentWorkflow);
   }
 
   for (auto fileName : jsonAnnotationFiles) {

--- a/ImageViewer/ImageViewer.xml
+++ b/ImageViewer/ImageViewer.xml
@@ -258,6 +258,14 @@
           <label>Workflow Steps</label>
           <default></default>
         </string-vector>
+        <string-vector>
+          <name>workflowPersistent</name>
+          <flag>W</flag>
+          <longflag>workflowPersistent</longflag>
+          <description>Specify Workflow Steps like "p,Pleura,10,1,b,ROI,1,p,Bone,10,1 that persist even when slices are changed."</description>
+          <label>Persistent Workflow Steps</label>
+          <default></default>
+        </string-vector>
         <integer>
           <name>fixedSliceDelta</name>
           <longflag>fixedSliceDelta</longflag>

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -261,9 +261,14 @@ public:
     cClickMode = m;
     };
   
-  void setWorkflowSteps(std::vector<std::unique_ptr<struct Step>> steps) {
-    cWorkflowSteps = std::move(steps);
-  }
+  void setWorkflowSteps(std::vector<std::unique_ptr<struct Step>> steps) 
+    { cWorkflowSteps = std::move(steps); };
+
+  void setUsePersistentWorkflow(bool upw)
+    { cUsePersistentWorkflow = upw; };
+
+  bool usePersistentWorkflow(void)
+    { return cUsePersistentWorkflow; };
 
   ClickModeType clickMode( void )
     { return cClickMode; };
@@ -597,8 +602,10 @@ protected:
 
   std::vector<std::unique_ptr<struct Step>> cWorkflowSteps;
   int cWorkflowIndex;
+  bool cUsePersistentWorkflow;
 
   OverlayPointer cOverlayData;
+  OverlayPointer cPrevOverlayData;
 
   unsigned char *cWinOverlayData;
   QDialog* cHelpDialog;


### PR DESCRIPTION
Use shift-U to undo most recent brush stroke or interpolation.

Allow optional persistent workflows that don't revert workflow
state when moving to a new slice.