### PR TITLE
CMakeLists.txt: Update minimum qt version required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #add_definitions( -DQT_STATIC )
 #add_definitions( -DQT_DESIGNER_STATIC )
 add_definitions( -DQT_THREAD_SUPPORT )
-find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
+find_package(Qt5 5.11 COMPONENTS Core Widgets Gui REQUIRED)
 
 find_package(SlicerExecutionModel REQUIRED)
 include(${SlicerExecutionModel_USE_FILE})

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This build should be relatively quick.
 *4) Qt5*
 
 Install Qt5 developer packages via [qt.io](qt.io) or via apt-get.
+Requires at least version 5.11.
 
 *5) ImageViewer*
 


### PR DESCRIPTION
`QFontMetrics.horizontalAdvance` not added until Qt 5.11: https://doc.qt.io/qt-5/qfontmetrics.html#horizontalAdvance

Updates the minimum required qt version in the `CMakeLists.txt` and adds a note to the readme