### PR TITLE
ENH: Load ruler annotations

### DIFF
--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -3179,4 +3179,11 @@ void QtGlSliceView::addRuler(
   auto collection = this->getRulerToolCollection(axis, slice);
   RulerTool* ruler = collection->createRuler(point1, point2, std::move(metaData));
 }
+
+void QtGlSliceView::initializeRulerMetadataFactories(int curRainbowId, int curOnsdId)
+{
+  this->cRainbowMetaFactory->initializeState(curRainbowId);
+  this->cONSDMetaFactory->initializeState(curOnsdId);
+}
+
 #endif

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -3169,18 +3169,6 @@ void QtGlSliceView::setIsONSDRuler(bool flag) {
     this->getRulerToolCollection()->setMetaDataFactory(cCurrentRulerMetaFactory);
 }
 
-void QtGlSliceView::addBox(
-    std::string name,
-    int axis,
-    int slice,
-    double point1[],
-    double point2[]
-) {
-  auto collection = this->getBoxToolCollection(axis, slice);
-  BoxTool* box = collection->createBox(point1, point2);
-  box->metaData.get()->name = name;
-}
-
 void QtGlSliceView::addRuler(
     int axis,
     int slice,

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -3124,13 +3124,17 @@ void QtGlSliceView::renderText( double x, double y, const QString & str,
     }
 }
 
-RulerToolCollection* QtGlSliceView::getRulerToolCollection() {
-    auto axis_slice = std::pair<int, int>(cWinOrder[2], this->sliceNum());
-    if (cRulerCollections.find(axis_slice) == cRulerCollections.end()) {
-        std::unique_ptr< RulerToolCollection > rc(new RulerToolCollection(this, cCurrentRulerMetaFactory, cWinOrder[2], this->sliceNum())); // TODO: figure out which axis we're talking about (remove 2)
-        cRulerCollections[axis_slice] = std::move(rc);
-    }
-    return cRulerCollections[axis_slice].get();
+RulerToolCollection *QtGlSliceView::getRulerToolCollection() {
+  return this->getRulerToolCollection(cWinOrder[2], this->sliceNum());
+}
+
+RulerToolCollection *QtGlSliceView::getRulerToolCollection(int axis, int sliceNum) {
+  auto axis_slice = std::pair<int, int>(axis, sliceNum);
+  if (cRulerCollections.find(axis_slice) == cRulerCollections.end()) {
+    std::unique_ptr<RulerToolCollection> rc(new RulerToolCollection(this, cCurrentRulerMetaFactory, axis, sliceNum)); // TODO: figure out which axis we're talking about (remove 2)
+    cRulerCollections[axis_slice] = std::move(rc);
+  }
+  return cRulerCollections[axis_slice].get();
 }
 
 BoxToolCollection* QtGlSliceView::getBoxToolCollection() {
@@ -3163,5 +3167,17 @@ void QtGlSliceView::addBox(
   auto collection = this->getBoxToolCollection(axis, slice);
   BoxTool* box = collection->createBox(point1, point2);
   box->metaData.get()->name = name;
+}
+
+void QtGlSliceView::addRuler(
+    std::string name,
+    int axis,
+    int slice,
+    double point1[],
+    double point2[]
+) {
+  auto collection = this->getRulerToolCollection(axis, slice);
+  RulerTool* ruler = collection->createRuler(point1, point2);
+  ruler->metaData.get()->name = name;
 }
 #endif

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -2386,7 +2386,6 @@ void QtGlSliceView::paintGL( void )
         posY = height() - 4 * (widgetFontMetric.height() + 1);
         this->renderText(posX, posY, s, widgetFont);
         }
-      getRulerToolCollection()->paint();
       glDisable(GL_BLEND);
       }
     else if (cClickMode == CM_BOX)
@@ -2536,6 +2535,7 @@ void QtGlSliceView::paintGL( void )
     {
     glEnable(GL_BLEND);
     getBoxToolCollection()->paint();
+    getRulerToolCollection()->paint();
     glDisable(GL_BLEND);
     }
 

--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -3170,14 +3170,13 @@ void QtGlSliceView::addBox(
 }
 
 void QtGlSliceView::addRuler(
-    std::string name,
     int axis,
     int slice,
     double point1[],
-    double point2[]
+    double point2[],
+    std::unique_ptr<RulerToolMetaData> metaData
 ) {
   auto collection = this->getRulerToolCollection(axis, slice);
-  RulerTool* ruler = collection->createRuler(point1, point2);
-  ruler->metaData.get()->name = name;
+  RulerTool* ruler = collection->createRuler(point1, point2, std::move(metaData));
 }
 #endif

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -48,6 +48,7 @@ class ONSDMetaDataGenerator;
 class RainbowMetaDataGenerator;
 class RulerToolMetaDataFactory;
 class BoxToolMetaDataFactory;
+struct RulerToolMetaData;
 
 using namespace itk;
 
@@ -417,6 +418,18 @@ public:
 
   void setInputImageFilepath(QString filepath);
 
+  /**
+  * Adds a ruler.
+  * \param name name of the ruler
+  * \param axis placed axis
+  * \param slice the slice number
+  * \param point1 first endpoint of the ruler
+  * \param point2 second endpoint of the ruler
+  * \param metaData optional metadata to use for the new ruler, if it already exists.
+  */
+  void addRuler(int axis, int slice, double point1[], double point2[], std::unique_ptr<RulerToolMetaData> metaData = nullptr);
+
+
 public slots:
   /// Set the displayState property value.
   /// \sa displayState, displayState()
@@ -566,16 +579,6 @@ public slots:
   * \param point2 bottom right of box
   */
   void addBox(std::string name, int axis, int slice, double point1[], double point2[]);
-
-   /**
-  * Adds a ruler.
-  * \param name name of the ruler
-  * \param axis placed axis
-  * \param slice the slice number
-  * \param point1 first endpoint of the ruler
-  * \param point2 second endpoint of the ruler
-  */
-  void addRuler(std::string name, int axis, int slice, double point1[], double point2[]);
 
 
 signals:

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -429,6 +429,14 @@ public:
   */
   void addRuler(int axis, int slice, double point1[], double point2[], std::unique_ptr<RulerToolMetaData> metaData = nullptr);
 
+  /**
+  * Initializes the state of the rainbow and onsd metadata factories
+  * based on the ids. The ids can be used to derive the states
+  * \param curRainbowId id to initialize the state of the RainbowRulerMetaDataGenerator
+  * \param curOnsdId id to initialize the state of the ONSDMetaDataGenerator
+  */
+  void initializeRulerMetadataFactories(int curRainbowId, int curOnsdId);
+
 
 public slots:
   /// Set the displayState property value.

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -567,6 +567,16 @@ public slots:
   */
   void addBox(std::string name, int axis, int slice, double point1[], double point2[]);
 
+   /**
+  * Adds a ruler.
+  * \param name name of the ruler
+  * \param axis placed axis
+  * \param slice the slice number
+  * \param point1 first endpoint of the ruler
+  * \param point2 second endpoint of the ruler
+  */
+  void addRuler(std::string name, int axis, int slice, double point1[], double point2[]);
+
 
 signals:
 
@@ -650,6 +660,7 @@ protected:
                                double maxX, double maxY, double maxZ,
                                void * clickBoxArg);
   RulerToolCollection* getRulerToolCollection();
+  RulerToolCollection *getRulerToolCollection(int axis, int sliceNum);
   BoxToolCollection* getBoxToolCollection();
   BoxToolCollection* getBoxToolCollection(int axis, int sliceNum);
 

--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -322,6 +322,7 @@ bool QtImageViewer::loadJSONAnnotations(QString filePathToLoad)
 
   const QJsonObject root = doc.object();
   status |= this->loadBoxAnnotations(root);
+  status |= this->loadRulerAnnotations(root);
   return status;
 }
 
@@ -412,3 +413,65 @@ bool QtImageViewer::loadBoxAnnotations(const QJsonObject &root)
   return true;
 }
 
+bool QtImageViewer::loadRulerAnnotations(const QJsonObject &root)
+{
+  if (!(root.contains("rulers") && root["rulers"].isArray()))
+  {
+    return false;
+  }
+
+  const QJsonArray slices = root["rulers"].toArray();
+  for (auto val1 : slices)
+  {
+    if (val1.isObject())
+    {
+      const QJsonObject slice = val1.toObject();
+      if (
+          slice.contains("axis") && slice["axis"].isDouble() &&
+          slice.contains("slice") && slice["slice"].isDouble() &&
+          slice.contains("rulers") && slice["rulers"].isArray())
+      {
+        const int axis = (int)slice["axis"].toDouble();
+        const int sliceNum = (int)slice["slice"].toDouble();
+        const QJsonArray rulers = slice["rulers"].toArray();
+        for (auto val2 : rulers)
+        {
+          if (val2.isObject())
+          {
+            const QJsonObject ruler = val2.toObject();
+            if (
+                ruler.contains("name") && ruler["name"].isString() &&
+                ruler.contains("indices") && ruler["indices"].isArray())
+            {
+              const QString name = ruler["name"].toString();
+              const QJsonArray indices = ruler["indices"].toArray();
+              if (
+                  indices.size() == 2 &&
+                  indices[0].isArray() &&
+                  indices[1].isArray())
+              {
+                const QJsonArray pt1Array = indices[0].toArray();
+                const QJsonArray pt2Array = indices[1].toArray();
+                if (pt1Array.size() == 3 && pt2Array.size() == 3)
+                {
+                  double point1[] = {
+                      pt1Array[0].toDouble(),
+                      pt1Array[1].toDouble(),
+                      pt1Array[2].toDouble(),
+                  };
+                  double point2[] = {
+                      pt2Array[0].toDouble(),
+                      pt2Array[1].toDouble(),
+                      pt2Array[2].toDouble(),
+                  };
+                  this->sliceView()->addRuler(name.toStdString(), axis, sliceNum, point1, point2);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return true;
+}

--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -327,7 +327,7 @@ bool QtImageViewer::loadJSONAnnotations(QString filePathToLoad)
   int maxOnsdId = 0;
   status |= this->loadRulerAnnotations(root, maxRainbowId, maxOnsdId);
 
-
+  this->sliceView()->setViewOverlayData(true);
   return status;
 }
 

--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -321,59 +321,7 @@ bool QtImageViewer::loadJSONAnnotations(QString filePathToLoad)
   bool status = false;
 
   const QJsonObject root = doc.object();
-  if (root.contains("boxes") && root["boxes"].isArray()) {
-    const QJsonArray slices = root["boxes"].toArray();
-    for (auto val1 : slices) {
-      if (val1.isObject()) {
-        const QJsonObject slice = val1.toObject();
-        if (
-          slice.contains("axis") && slice["axis"].isDouble() &&
-          slice.contains("slice") && slice["slice"].isDouble() &&
-          slice.contains("boxes") && slice["boxes"].isArray()
-        ) {
-          const int axis = (int)slice["axis"].toDouble();
-          const int sliceNum = (int)slice["slice"].toDouble();
-          const QJsonArray boxes = slice["boxes"].toArray();
-          for (auto val2 : boxes) {
-            if (val2.isObject()) {
-              const QJsonObject box = val2.toObject();
-              if (
-                box.contains("name") && box["name"].isString() &&
-                box.contains("indices") && box["indices"].isArray()
-              ) {
-                const QString name = box["name"].toString();
-                const QJsonArray indices = box["indices"].toArray();
-                if (
-                  indices.size() == 2 &&
-                  indices[0].isArray() &&
-                  indices[1].isArray()
-                ) {
-                  const QJsonArray pt1Array = indices[0].toArray();
-                  const QJsonArray pt2Array = indices[1].toArray();
-                  if (pt1Array.size() == 3 && pt2Array.size() == 3) {
-                    double point1[] = {
-                      pt1Array[0].toDouble(),
-                      pt1Array[1].toDouble(),
-                      pt1Array[2].toDouble(),
-                    };
-                    double point2[] = {
-                      pt2Array[0].toDouble(),
-                      pt2Array[1].toDouble(),
-                      pt2Array[2].toDouble(),
-                    };
-                    this->sliceView()->addBox(name.toStdString(), axis, sliceNum, point1, point2);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    status = true;
-  }
-
+  status |= this->loadBoxAnnotations(root);
   return status;
 }
 
@@ -400,3 +348,67 @@ void QtImageViewer::releaseFixedSize()
   Q_D(QtImageViewer);
   d->OpenGlWindow->setFixedSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
 }
+
+bool QtImageViewer::loadBoxAnnotations(const QJsonObject &root)
+{
+  if (!(root.contains("boxes") && root["boxes"].isArray()))
+  {
+    return false;
+  }
+
+  const QJsonArray slices = root["boxes"].toArray();
+  for (auto val1 : slices)
+  {
+    if (val1.isObject())
+    {
+      const QJsonObject slice = val1.toObject();
+      if (
+          slice.contains("axis") && slice["axis"].isDouble() &&
+          slice.contains("slice") && slice["slice"].isDouble() &&
+          slice.contains("boxes") && slice["boxes"].isArray())
+      {
+        const int axis = (int)slice["axis"].toDouble();
+        const int sliceNum = (int)slice["slice"].toDouble();
+        const QJsonArray boxes = slice["boxes"].toArray();
+        for (auto val2 : boxes)
+        {
+          if (val2.isObject())
+          {
+            const QJsonObject box = val2.toObject();
+            if (
+                box.contains("name") && box["name"].isString() &&
+                box.contains("indices") && box["indices"].isArray())
+            {
+              const QString name = box["name"].toString();
+              const QJsonArray indices = box["indices"].toArray();
+              if (
+                  indices.size() == 2 &&
+                  indices[0].isArray() &&
+                  indices[1].isArray())
+              {
+                const QJsonArray pt1Array = indices[0].toArray();
+                const QJsonArray pt2Array = indices[1].toArray();
+                if (pt1Array.size() == 3 && pt2Array.size() == 3)
+                {
+                  double point1[] = {
+                      pt1Array[0].toDouble(),
+                      pt1Array[1].toDouble(),
+                      pt1Array[2].toDouble(),
+                  };
+                  double point2[] = {
+                      pt2Array[0].toDouble(),
+                      pt2Array[1].toDouble(),
+                      pt2Array[2].toDouble(),
+                  };
+                  this->sliceView()->addBox(name.toStdString(), axis, sliceNum, point1, point2);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+

--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -441,10 +441,19 @@ bool QtImageViewer::loadRulerAnnotations(const QJsonObject &root)
             const QJsonObject ruler = val2.toObject();
             if (
                 ruler.contains("name") && ruler["name"].isString() &&
-                ruler.contains("indices") && ruler["indices"].isArray())
+                ruler.contains("indices") && ruler["indices"].isArray() &&
+                ruler.contains("color") && ruler["color"].isString() &&
+                ruler.contains("sortId"))
             {
               const QString name = ruler["name"].toString();
               const QJsonArray indices = ruler["indices"].toArray();
+              const QColor color = ruler["color"].toString();
+              // Note that here we assume -1 will never be used as an ID
+              int sortId = ruler["sortId"].toInt(-1);
+              if (sortId == -1)
+              {
+                return false;
+              }
               if (
                   indices.size() == 2 &&
                   indices[0].isArray() &&
@@ -464,7 +473,8 @@ bool QtImageViewer::loadRulerAnnotations(const QJsonObject &root)
                       pt2Array[1].toDouble(),
                       pt2Array[2].toDouble(),
                   };
-                  this->sliceView()->addRuler(name.toStdString(), axis, sliceNum, point1, point2);
+                  std::unique_ptr< RulerToolMetaData > metaData(new RulerToolMetaData{ sortId, name.toStdString(), color });
+                  this->sliceView()->addRuler(axis, sliceNum, point1, point2, std::move(metaData));
                 }
               }
             }

--- a/QtImageViewer/QtImageViewer.h
+++ b/QtImageViewer/QtImageViewer.h
@@ -24,13 +24,14 @@ limitations under the License.
 
 // Qt includes
 #include <QDialog>
+#include <QJsonObject>
 
 // ITK includes
 #include <itkImage.h>
 
 // ImageViewer includes
 #include "QtImageViewer_Export.h"
-class QtGlSliceView;
+    class QtGlSliceView;
 class QtImageViewerPrivate;
 
 class QtImageViewer_EXPORT QtImageViewer : public QDialog
@@ -81,6 +82,7 @@ protected:
 private:
   Q_DECLARE_PRIVATE(QtImageViewer);
   Q_DISABLE_COPY(QtImageViewer);
+  bool loadBoxAnnotations(const QJsonObject& root);
 };
 
 #endif

--- a/QtImageViewer/QtImageViewer.h
+++ b/QtImageViewer/QtImageViewer.h
@@ -83,6 +83,7 @@ private:
   Q_DECLARE_PRIVATE(QtImageViewer);
   Q_DISABLE_COPY(QtImageViewer);
   bool loadBoxAnnotations(const QJsonObject& root);
+  bool loadRulerAnnotations(const QJsonObject& root);
 };
 
 #endif

--- a/QtImageViewer/QtImageViewer.h
+++ b/QtImageViewer/QtImageViewer.h
@@ -83,6 +83,7 @@ private:
   Q_DECLARE_PRIVATE(QtImageViewer);
   Q_DISABLE_COPY(QtImageViewer);
   bool loadBoxAnnotations(const QJsonObject& root);
+  bool loadRulerAnnotations(const QJsonObject& root, int& max_rainbow_id, int& max_onsd_id);
   bool loadRulerAnnotations(const QJsonObject& root);
 };
 

--- a/QtImageViewer/RulerWidget.cxx
+++ b/QtImageViewer/RulerWidget.cxx
@@ -144,8 +144,10 @@ std::string RulerTool::toJson() {
     char txt[256];
 
     int n = snprintf(txt, sizeof(txt),
-        "{ \"name\" : \"%s\", \"indices\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ], \"points\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ], \"distance\" : %.4f}",
+        "{ \"sortId\" : %d, \"name\" : \"%s\", \"color\" : \"%s\", \"indices\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ], \"points\" : [ [%.4f, %.4f, %.4f], [%.4f, %.4f, %.4f] ], \"distance\" : %.4f}",
+        metaData->sortId,
         metaData->name.c_str(),
+        metaData->color.name().toStdString().c_str(),
         indices[0].GetElement(0),
         indices[0].GetElement(1),
         indices[0].GetElement(2),
@@ -231,17 +233,22 @@ void RulerToolCollection::handleMouseEvent(QMouseEvent* event, double index[]) {
 
 }
 
-RulerTool* RulerToolCollection::createRuler(double point1[])
+RulerTool* RulerToolCollection::createRuler(double point1[], std::unique_ptr<RulerToolMetaData> metaData)
 {
-  std::unique_ptr<RulerTool> r(new RulerTool(this->parent, RulerTool::PointType3D(point1), metaDataFactory->getNext()));
+  if (!metaData)
+  {
+    metaData = metaDataFactory->getNext();
+  }
+
+  std::unique_ptr<RulerTool> r(new RulerTool(this->parent, RulerTool::PointType3D(point1), std::move(metaData)));
   auto rulerTool = r.get();
   this->rulers.push_back(std::move(r));
   return rulerTool;
 }
 
-RulerTool* RulerToolCollection::createRuler(double point1[], double point2[])
+RulerTool* RulerToolCollection::createRuler(double point1[], double point2[], std::unique_ptr<RulerToolMetaData> metaData)
 {
-  auto r = this->createRuler(point1);
+  auto r = this->createRuler(point1, std::move(metaData));
   r->setFloatingIndex(1);
   r->updateFloatingIndex(point2);
   return r;

--- a/QtImageViewer/RulerWidget.cxx
+++ b/QtImageViewer/RulerWidget.cxx
@@ -30,6 +30,12 @@ std::unique_ptr< RulerToolMetaData > RainbowRulerMetaDataGenerator::operator()(v
     return std::unique_ptr< RulerToolMetaData >(new RulerToolMetaData{ id, name, color });
 }
 
+void RainbowRulerMetaDataGenerator::initializeState(int curId)
+{
+  this->curId = curId;
+  this->curColor += (curId % this->colors.size());
+}
+
 std::unique_ptr< RulerToolMetaData > ONSDRulerMetaDataGenerator::operator()(void) {
     std::string name = flipper ? "R1" : "ONSD";
     QColor color = QColor(colors[(int)flipper].c_str());
@@ -39,6 +45,12 @@ std::unique_ptr< RulerToolMetaData > ONSDRulerMetaDataGenerator::operator()(void
     ++curId;
 
     return std::unique_ptr< RulerToolMetaData >(new RulerToolMetaData{ id, name, color });
+}
+
+void ONSDRulerMetaDataGenerator::initializeState(int curId)
+{
+  this->curId = curId;
+  this->flipper = (curId % 2 == 0);
 }
 
 
@@ -59,6 +71,11 @@ std::unique_ptr< RulerToolMetaData > RulerToolMetaDataFactory::getNext() {
 void RulerToolMetaDataFactory::refund(std::unique_ptr< RulerToolMetaData > ruler_meta) {
     refunds.push_back(std::move(ruler_meta));
     std::sort(refunds.begin(), refunds.end());
+}
+
+void RulerToolMetaDataFactory::initializeState(int curId)
+{
+  this->generator->initializeState(curId);
 }
 
 RulerTool::RulerTool(QtGlSliceView* parent0, PointType3D index0, std::unique_ptr< RulerToolMetaData > metaData) :

--- a/QtImageViewer/RulerWidget.cxx
+++ b/QtImageViewer/RulerWidget.cxx
@@ -199,9 +199,7 @@ void RulerToolCollection::handleMouseEvent(QMouseEvent* event, double index[]) {
         // we're idle and we're clicking to create a new ruler
         if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::LeftButton) {
             // blank click on screen, make a ruler
-
-            std::unique_ptr< RulerTool > r(new RulerTool(this->parent, RulerTool::PointType3D(index), metaDataFactory->getNext()));
-            this->rulers.push_back(std::move(r));
+            this->createRuler(index);
             this->currentId = this->rulers.size() - 1;
             this->state = RulerToolState::drawing;
             this->paint();
@@ -231,6 +229,22 @@ void RulerToolCollection::handleMouseEvent(QMouseEvent* event, double index[]) {
         break;
     }
 
+}
+
+RulerTool* RulerToolCollection::createRuler(double point1[])
+{
+  std::unique_ptr<RulerTool> r(new RulerTool(this->parent, RulerTool::PointType3D(point1), metaDataFactory->getNext()));
+  auto rulerTool = r.get();
+  this->rulers.push_back(std::move(r));
+  return rulerTool;
+}
+
+RulerTool* RulerToolCollection::createRuler(double point1[], double point2[])
+{
+  auto r = this->createRuler(point1);
+  r->setFloatingIndex(1);
+  r->updateFloatingIndex(point2);
+  return r;
 }
 
 void RulerToolCollection::setMetaDataFactory(std::shared_ptr< RulerToolMetaDataFactory > factory) {

--- a/QtImageViewer/RulerWidget.h
+++ b/QtImageViewer/RulerWidget.h
@@ -73,6 +73,7 @@ bool operator< (std::unique_ptr< RulerToolMetaData > const& lhs, std::unique_ptr
 class RulerMetaDataGenerator {
 public:
     virtual std::unique_ptr< RulerToolMetaData > operator()(void) = 0;
+    virtual void initializeState(int curId) = 0;
 };
 
 /**
@@ -83,6 +84,9 @@ public:
     RainbowRulerMetaDataGenerator();
 
     std::unique_ptr< RulerToolMetaData > operator()(void);
+
+    // Note, this does not take the current state of the generator into account
+    virtual void initializeState(int curId);
 protected:
     std::vector< std::string > colors = { "#F8766D", "#BB9D00", "#00B81F", "#00C0B8", "#00A5FF", "#E76BF3", "#FF6C90" };
     std::vector< std::string >::iterator curColor;
@@ -98,6 +102,9 @@ public:
     ONSDRulerMetaDataGenerator() { };
 
     std::unique_ptr< RulerToolMetaData > operator()(void);
+
+    // Note, this does not take the current state of the generator into account
+    virtual void initializeState(int curId);
 protected:
     std::vector< std::string > colors = { "#F8766D", "#BB9D00" };
     bool flipper = true;
@@ -125,6 +132,8 @@ public:
     * Return a deleted meta data for reuse.
     */
     void refund(std::unique_ptr< RulerToolMetaData > ruler_meta);
+
+    void initializeState(int curId);
 
 protected:
     std::unique_ptr< RulerMetaDataGenerator > generator;

--- a/QtImageViewer/RulerWidget.h
+++ b/QtImageViewer/RulerWidget.h
@@ -225,6 +225,18 @@ public:
     virtual ~RulerToolCollection();
 
     /**
+    * Creates a ruler. Only sets one endpoint.
+    * \param point1 the 3D endpoint to set (in image index space)
+    */
+    RulerTool* createRuler(double point1[]);
+    /**
+    * Creates a ruler.
+    * \param point1 the first 3D endpoint to set (in image index space)
+    * \param point2 the second 3D endpoint to set (in image index space)
+    */
+    RulerTool* createRuler(double point1[], double point2[]);
+
+    /**
     * Note, QtGlSliceView does all the computation to determine screen coordinate to image index space.  So we do a lot of image index space back
     * to screen coordinates.
     * 

--- a/QtImageViewer/RulerWidget.h
+++ b/QtImageViewer/RulerWidget.h
@@ -227,14 +227,16 @@ public:
     /**
     * Creates a ruler. Only sets one endpoint.
     * \param point1 the 3D endpoint to set (in image index space)
+    * \param metaData optional metadata to use for the new ruler, if it already exists.
     */
-    RulerTool* createRuler(double point1[]);
+    RulerTool* createRuler(double point1[], std::unique_ptr<RulerToolMetaData> metaData = nullptr);
     /**
     * Creates a ruler.
     * \param point1 the first 3D endpoint to set (in image index space)
     * \param point2 the second 3D endpoint to set (in image index space)
+    * \param metaData optional metadata to use for the new ruler, if it already exists.
     */
-    RulerTool* createRuler(double point1[], double point2[]);
+    RulerTool* createRuler(double point1[], double point2[], std::unique_ptr<RulerToolMetaData> metaData = nullptr);
 
     /**
     * Note, QtGlSliceView does all the computation to determine screen coordinate to image index space.  So we do a lot of image index space back


### PR DESCRIPTION
Load in ruler annotations. Resolves #118 

Other changes:
* Write out ruler annotation metadata to json
* Use the metadata to reinitialize the state of the onsd and rainbow metadata generators, so the user can pick up where they left off after reading in annotations

TODO:
- [x] Should we always show the ruler annotations when viewing overlay data? Similar to https://github.com/KitwareMedical/ImageViewer/pull/101/commits/4956c6882e0825293181fb861a8e29fa646031fb. What if the user shows ruler and box annotations at the same time?