### PR TITLE
QtGlSliceView: Move addBox out of slots

### DIFF
--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -3082,6 +3082,18 @@ void QtGlSliceView::setInputImageFilepath(QString filepath) {
     this->inputImageFilepath = filepath;
 }
 
+void QtGlSliceView::addBox(
+    std::string name,
+    int axis,
+    int slice,
+    double point1[],
+    double point2[]
+) {
+  auto collection = this->getBoxToolCollection(axis, slice);
+  BoxTool* box = collection->createBox(point1, point2);
+  box->metaData.get()->name = name;
+}
+
 void QtGlSliceView::zoomOut()
 {
   if( zoom() <= 1 )
@@ -3153,15 +3165,4 @@ void QtGlSliceView::setIsONSDRuler(bool flag) {
     this->getRulerToolCollection()->setMetaDataFactory(cCurrentRulerMetaFactory);
 }
 
-void QtGlSliceView::addBox(
-    std::string name,
-    int axis,
-    int slice,
-    double point1[],
-    double point2[]
-) {
-  auto collection = this->getBoxToolCollection(axis, slice);
-  BoxTool* box = collection->createBox(point1, point2);
-  box->metaData.get()->name = name;
-}
 #endif

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -417,6 +417,16 @@ public:
 
   void setInputImageFilepath(QString filepath);
 
+  /**
+  * Adds a box.
+  * \param name name of the box
+  * \param axis placed axis
+  * \param slice the slice number
+  * \param point1 top left of box
+  * \param point2 bottom right of box
+  */
+  void addBox(std::string name, int axis, int slice, double point1[], double point2[]);
+
 public slots:
   /// Set the displayState property value.
   /// \sa displayState, displayState()
@@ -556,16 +566,6 @@ public slots:
   * \param flag
   */
   void setIsONSDRuler(bool flag);
-
-  /**
-  * Adds a box.
-  * \param name name of the box
-  * \param axis placed axis
-  * \param slice the slice number
-  * \param point1 top left of box
-  * \param point2 bottom right of box
-  */
-  void addBox(std::string name, int axis, int slice, double point1[], double point2[]);
 
 
 signals:


### PR DESCRIPTION
Moves `QtGlSliceView::addBox` out of the `public slots` section. As far as I can tell, it isn't used as a slot