### PR TITLE
ENH: Add corner text

### DIFF
--- a/ImageViewer/ImageViewer.cxx
+++ b/ImageViewer/ImageViewer.cxx
@@ -549,9 +549,13 @@ int parseAndExecImageViewer(int argc, char* argv[])
         step->factory = factory;
 
         steps.push_back(std::move(step));
+      }else if (type == "t" || type == "T") {
+        std::string defaultText = workflow[i++];
+        viewer.sliceView()->setDefaultDialogBoxText(QString::fromStdString(defaultText));
+
       }else
       {
-        throw std::runtime_error("Use p, P, b, B, r, R for this switch");
+        throw std::runtime_error("Use p, P, b, B, r, R, t, T for this switch");
       }
     }
 

--- a/QtImageViewer/QtGlSliceView.h
+++ b/QtImageViewer/QtGlSliceView.h
@@ -447,6 +447,67 @@ public:
   */
   void addBox(std::string name, int axis, int slice, double point1[], double point2[]);
 
+  /**
+  * Adds corner text to display.
+  * If an empty string is passed in, the text for the passed frame
+  * and axis is removed.
+  * \param axis placed axis
+  * \param slice the slice number
+  * \param text text to display
+  */
+  void setCornerText(int axis, int slice, QString text);
+
+  /**
+  * Adds corner text to display at the current axis and slice.
+  * If an empty string is passed in, the text for the current frame
+  * and axis is removed.
+  * \param text text to display
+  */
+  void setCornerText(QString text);
+
+   /**
+  * Gets the corner text to display.
+  * If an empty string is returned, there is no corner text
+  * for the given axis and slice
+  * \param axis placed axis
+  * \param slice the slice number
+  */
+  QString getCornerText(int axis, int slice);
+
+  /**
+  * Gets corner text displayed at the current axis and slice.
+  * If an empty string is returned, there is no corner text
+  * for the current axis and slice
+  */
+  QString getCornerText();
+
+  /**
+  * Removes the corner text at the current axis and slice.
+  */
+  void removeCornerText();
+
+   /**
+  * Removes the corner text.
+  * \param axis placed axis
+  * \param slice the slice number
+  */
+  void removeCornerText(int axis, int slice);
+
+  /**
+  * Gets the current axis and slice as a std::pair
+  */
+  std::pair<int, int> getCurrentAxisAndSlice();
+
+  /**
+   * Sets the default dialog box text
+  */
+  void setDefaultDialogBoxText(QString s);
+
+  /**
+   * Gets the default dialog box text
+  */
+  const QString& getDefaultDialogBoxText();
+
 public slots:
   /// Set the displayState property value.
   /// \sa displayState, displayState()
@@ -503,6 +564,8 @@ public slots:
   void saveRulers( std::string fileName );
   void saveBoxesWithPrompt( void );
   void saveBoxes( std::string fileName );
+  void saveCornerTextWithPrompt( void );
+  void saveCornerText( std::string fileName );
 
   void setIWModeMin(IWModeType newIWModeMin);
   void setIWModeMin(const char* mode);
@@ -754,6 +817,10 @@ protected:
   std::shared_ptr< BoxToolMetaDataFactory > cCurrentBoxMetaFactory;
   std::map< std::pair<int, int>, std::unique_ptr< RulerToolCollection > > cRulerCollections;
   std::map< std::pair<int, int>, std::unique_ptr< BoxToolCollection > > cBoxCollections;
+
+  // Should never contain empty qstrings
+  std::map< std::pair<int, int>, QString > cCornerTextCollection;
+  QString defaultDialogBoxText;
 };
   
 #endif

--- a/QtImageViewer/QtImageViewer.cxx
+++ b/QtImageViewer/QtImageViewer.cxx
@@ -327,6 +327,8 @@ bool QtImageViewer::loadJSONAnnotations(QString filePathToLoad)
   int maxOnsdId = 0;
   status |= this->loadRulerAnnotations(root, maxRainbowId, maxOnsdId);
 
+  status |= this->loadCornerTextAnnotations(root);
+
   this->sliceView()->setViewOverlayData(true);
   return status;
 }
@@ -519,3 +521,30 @@ bool QtImageViewer::loadRulerAnnotations(const QJsonObject &root)
   return this->loadRulerAnnotations(root, maxRainbowId, maxOnsdId);
 }
 
+bool QtImageViewer::loadCornerTextAnnotations(const QJsonObject &root)
+{
+  if (!(root.contains("cornerTexts") && root["cornerTexts"].isArray()))
+  {
+    return false;
+  }
+
+  const QJsonArray slices = root["cornerTexts"].toArray();
+  for (auto val1 : slices)
+  {
+    if (val1.isObject())
+    {
+      const QJsonObject slice = val1.toObject();
+      if (
+          slice.contains("axis") && slice["axis"].isDouble() &&
+          slice.contains("slice") && slice["slice"].isDouble() &&
+          slice.contains("text") && slice["text"].isString())
+      {
+        const int axis = (int)slice["axis"].toDouble();
+        const int sliceNum = (int)slice["slice"].toDouble();
+        const QString cornerText = slice["text"].toString();
+        this->sliceView()->setCornerText(axis, sliceNum, cornerText);
+      }
+    }
+  }
+  return true;
+}

--- a/QtImageViewer/QtImageViewer.h
+++ b/QtImageViewer/QtImageViewer.h
@@ -85,6 +85,7 @@ private:
   bool loadBoxAnnotations(const QJsonObject& root);
   bool loadRulerAnnotations(const QJsonObject& root, int& max_rainbow_id, int& max_onsd_id);
   bool loadRulerAnnotations(const QJsonObject& root);
+  bool loadCornerTextAnnotations(const QJsonObject& root);
 };
 
 #endif


### PR DESCRIPTION
Adds the ability to put text in the upper right corner. By pressing the `g` key, a dialog box will pop up, which can be populated with text. Press OK, and the text will appear in the top right

Default text for the dialog box can also be specified with `./ImageViewer <image_path> -w "t,default_text_here"`

Supports the saving and loading of annotations

TODO:
- [x] How to remove corner text once already added?