### PR TITLE
BUG: Switch workflow steps after frame is changed

### DIFF
--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -1402,11 +1402,13 @@ void QtGlSliceView::switchWorkflowStep( int index )
     auto boxStep = static_cast<BoxStep*>(step.get());
     auto collection = getBoxToolCollection();
     collection->setMetaDataFactory(boxStep->factory);
+    this->cCurrentBoxMetaFactory = boxStep->factory;
   } else if (step->type == CM_RULER) {
     setClickMode(CM_RULER);
     auto rulerStep = static_cast<RulerStep *>(step.get());
     auto collection = getRulerToolCollection();
     collection->setMetaDataFactory(rulerStep->factory);
+    this->cCurrentRulerMetaFactory = rulerStep->factory;
   }
 }
 
@@ -1650,11 +1652,6 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
         {
         movePace = cFixedSliceMoveValue;
         }
-      if( !cUsePersistentWorkflow && cWorkflowSteps.size() != 0 ) 
-        {
-        cWorkflowIndex = 0;
-        switchWorkflowStep(cWorkflowIndex);
-        }
       if ((int)cWinCenter[cWinOrder[2]] - movePace < 0)
         {
         if ((int)cWinCenter[cWinOrder[2]] == 0)
@@ -1669,6 +1666,11 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
       else
         {
         setSliceNum((int)cWinCenter[cWinOrder[2]] - movePace);
+        }
+      if( !cUsePersistentWorkflow && cWorkflowSteps.size() != 0 ) 
+        {
+        cWorkflowIndex = 0;
+        switchWorkflowStep(cWorkflowIndex);
         }
       update();
       break;
@@ -1777,11 +1779,6 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
         {
         movePace = cFixedSliceMoveValue;
         }
-      if( !cUsePersistentWorkflow && cWorkflowSteps.size() != 0 ) 
-        {
-        cWorkflowIndex = 0;
-        switchWorkflowStep(cWorkflowIndex);
-        }
       if( ( int )cWinCenter[cWinOrder[2]]+movePace >=
           ( int )cDimSize[cWinOrder[2]]-1 )
         {
@@ -1790,6 +1787,11 @@ void QtGlSliceView::keyPressEvent(QKeyEvent* keyEvent)
       else
         {
         setSliceNum( ( int )cWinCenter[cWinOrder[2]]+movePace );
+        }
+      if( !cUsePersistentWorkflow && cWorkflowSteps.size() != 0 ) 
+        {
+        cWorkflowIndex = 0;
+        switchWorkflowStep(cWorkflowIndex);
         }
       update();
       break;


### PR DESCRIPTION
By default, workflow steps are incremented on a frame change. When a frame change was detected, the workflow step would first be incremented, then the frame would be changed. The order has been switched here (frame is changed first, then the workflow step). When the workflow step is changed, the metadata factory for whatever tool is being used (box, ruler, etc.) is updated for the _current_ frame. If the frame hasn't changed yet (as was previously the case), it will have no effect. Then, after the frame has changed, the default factory from the [constructor](https://github.com/KitwareMedical/ImageViewer/blob/master/QtImageViewer/QtGlSliceView.cxx#L199) will be used to generate new objects.

As an MRE, run:

`./ImageViewer <path_to_file> -w "b,ROI,1"`. Left click to draw a bounding box (it should be red), then press `,` to switch frames. Draw another bounding box and it should be yellow. This is because the metadata for the previous frame was changed, not the new frame.

The changes in this PR should fix the MRE