### PR TITLE
BUG: Fix `setIsONSDRuler`

### DIFF
--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -3163,7 +3163,7 @@ BoxToolCollection* QtGlSliceView::getBoxToolCollection(int axis, int sliceNum) {
 }
 
 void QtGlSliceView::setIsONSDRuler(bool flag) {
-    isONSDRuler = !isONSDRuler;
+    isONSDRuler = flag;
     cCurrentRulerMetaFactory = isONSDRuler ? cONSDMetaFactory : cRainbowMetaFactory;
 
     this->getRulerToolCollection()->setMetaDataFactory(cCurrentRulerMetaFactory);


### PR DESCRIPTION
Switches the definition of [`setIsONSDRuler`](https://github.com/KitwareMedical/ImageViewer/blob/master/QtImageViewer/QtGlSliceView.cxx#L3165) to change the underlying `isONSDRuler` to the passed in flag. Previously, the function would just toggle the underlying flag, ignoring the parameter.

As an MRE, run `ImageViewer`, and try drawing a ruler. Notice that the ruler is an onsd ruler, despite the `isONSDRuler` flag being set to false in the [constructor](https://github.com/KitwareMedical/ImageViewer/blob/master/QtImageViewer/QtGlSliceView.cxx#L195)

This is due to the switch that happens in [`ImageViewer.cxx`](https://github.com/KitwareMedical/ImageViewer/blob/master/ImageViewer/ImageViewer.cxx#L431). If the `-R` flag is not present, the `setIsONSDRuler` call shouldn't change the value of the `isONSDRuler` variable. Since the function ignores its argument and simply toggles the variable, `isONSDRuler` is changed from `false` to `true`, so by default, onsd rulers are drawn.