### PR TITLE
BUG: Image voxel aspect ratio changed when window resized

### DIFF
--- a/QtImageViewer/QtGlSliceView.cxx
+++ b/QtImageViewer/QtGlSliceView.cxx
@@ -2281,8 +2281,9 @@ void QtGlSliceView::paintGL( void )
     return;
     }
 
-  double scale0 = this->width() / (double) cWinSizeX;
-  double scale1 = this->height() / (double) cWinSizeY;
+  int sizeMax = qMax(this->width(), this->height());
+  double scale0 = sizeMax / (double) cWinSizeX;
+  double scale1 = sizeMax / (double) cWinSizeY;
   int originX = (int)( -cWinMinX * scale0 );
   if( originX < 0 )
     {


### PR DESCRIPTION
If the window isn't square, it would cause the aspect ratio of the image voxel size to become incorrect.

Now the image voxel spacing doesn't appear to change if the height/width ratio of the window isn't 1.